### PR TITLE
Implement configuring path to individual endpoint

### DIFF
--- a/src/Steeltoe.Management.EndpointBase/AbstractEndpoint.cs
+++ b/src/Steeltoe.Management.EndpointBase/AbstractEndpoint.cs
@@ -36,7 +36,7 @@ namespace Steeltoe.Management.Endpoint
 
         public virtual IEndpointOptions Options => options;
 
-        public string Path => options.Path;
+        public string Path => options.FullPath;
     }
 
 #pragma warning disable SA1402 // File may only contain a single class

--- a/src/Steeltoe.Management.EndpointBase/AbstractOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/AbstractOptions.cs
@@ -120,22 +120,43 @@ namespace Steeltoe.Management.Endpoint
 
         public virtual string Id { get; set; }
 
-        public virtual string Path
+        public string Path { get; set; } = string.Empty;
+
+        public virtual string FullPath
         {
             get
             {
                 string path = Global.Path;
-                if (string.IsNullOrEmpty(Id))
-                {
-                    return path;
-                }
 
-                if (!path.EndsWith("/"))
+                // No path override -> use ID in path
+                if (string.IsNullOrEmpty(Path))
                 {
-                    path = path + "/";
-                }
+                    if (string.IsNullOrEmpty(Id))
+                    {
+                        return path;
+                    }
 
-                return path + Id;
+                    if (!path.EndsWith("/"))
+                    {
+                        path = path + "/";
+                    }
+
+                    return path + Id;
+                }
+                else
+                {
+                    // Ensure exactly one slash ends up between the prefix and the path
+                    if (path.EndsWith("/") && Path.StartsWith("/"))
+                    {
+                        path = path.Remove(path.Length - 1);
+                    }
+                    else if (!path.EndsWith("/") && !Path.StartsWith("/"))
+                    {
+                        path = path + "/";
+                    }
+
+                    return path + Path;
+                }
             }
         }
 

--- a/src/Steeltoe.Management.EndpointBase/CloudFoundry/SecurityBase.cs
+++ b/src/Steeltoe.Management.EndpointBase/CloudFoundry/SecurityBase.cs
@@ -49,7 +49,7 @@ namespace Steeltoe.Management.Endpoint.CloudFoundry
 
         public bool IsCloudFoundryRequest(string requestPath)
         {
-            bool startsWith = requestPath.StartsWith(_options.Path);
+            bool startsWith = requestPath.StartsWith(_options.FullPath);
             return startsWith;
         }
 

--- a/src/Steeltoe.Management.EndpointBase/IEndpointOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/IEndpointOptions.cs
@@ -30,8 +30,6 @@ namespace Steeltoe.Management.Endpoint
 
         string Id { get;  }
 
-        string Path { get; }
-
         string FullPath { get; }
 
         Permissions RequiredPermissions { get; }

--- a/src/Steeltoe.Management.EndpointBase/IEndpointOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/IEndpointOptions.cs
@@ -32,6 +32,8 @@ namespace Steeltoe.Management.Endpoint
 
         string Path { get; }
 
+        string FullPath { get; }
+
         Permissions RequiredPermissions { get; }
 
         bool IsAccessAllowed(Permissions permissions);

--- a/src/Steeltoe.Management.EndpointBase/Steeltoe.Management.EndpointBase.csproj
+++ b/src/Steeltoe.Management.EndpointBase/Steeltoe.Management.EndpointBase.csproj
@@ -49,6 +49,7 @@
   </ItemGroup>
   <PropertyGroup>
     <NoWarn>SA1101;SA1124;SA1201;SA1309;SA1310;SA1401;SA1600;SA1652;1591</NoWarn>
+    <Version>2.1.0-rc1</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/Steeltoe.Management.EndpointCore/CloudFoundry/CloudFoundrySecurityMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointCore/CloudFoundry/CloudFoundrySecurityMiddleware.cs
@@ -105,7 +105,7 @@ namespace Steeltoe.Management.Endpoint.CloudFoundry
             var configEndpoints = this._options.Global.EndpointOptions;
             foreach (var ep in configEndpoints)
             {
-                PathString epPath = new PathString(ep.Path);
+                PathString epPath = new PathString(ep.FullPath);
                 if (path.StartsWithSegments(epPath))
                 {
                     return ep;

--- a/src/Steeltoe.Management.EndpointCore/Mappings/MappingsEndpointMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointCore/Mappings/MappingsEndpointMiddleware.cs
@@ -98,7 +98,7 @@ namespace Steeltoe.Management.Endpoint.Mappings
                 return false;
             }
 
-            PathString path = new PathString(_options.Path);
+            PathString path = new PathString(_options.FullPath);
             return context.Request.Path.Equals(path);
         }
 

--- a/src/Steeltoe.Management.EndpointOwin/CloudFoundry/CloudFoundrySecurityOwinMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointOwin/CloudFoundry/CloudFoundrySecurityOwinMiddleware.cs
@@ -124,7 +124,7 @@ namespace Steeltoe.Management.EndpointOwin.CloudFoundry
             var configEndpoints = this._options.Global.EndpointOptions;
             foreach (var ep in configEndpoints)
             {
-                PathString epPath = new PathString(ep.Path);
+                PathString epPath = new PathString(ep.FullPath);
                 if (path.StartsWithSegments(epPath))
                 {
                     return ep;

--- a/src/Steeltoe.Management.EndpointOwin/Mappings/MappingsEndpointOwinMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointOwin/Mappings/MappingsEndpointOwinMiddleware.cs
@@ -57,8 +57,8 @@ namespace Steeltoe.Management.EndpointOwin.Mappings
 
         public override bool RequestVerbAndPathMatch(string httpMethod, string requestPath)
         {
-            _logger?.LogTrace("RequestVerbAndPathMatch {httpMethod}/{requestPath}/{optionsPath} request", httpMethod, requestPath, _options.Path);
-            return requestPath.Equals(_options.Path) && _allowedMethods.Any(m => m.Method.Equals(httpMethod));
+            _logger?.LogTrace("RequestVerbAndPathMatch {httpMethod}/{requestPath}/{optionsPath} request", httpMethod, requestPath, _options.FullPath);
+            return requestPath.Equals(_options.FullPath) && _allowedMethods.Any(m => m.Method.Equals(httpMethod));
         }
 
         protected internal ApplicationMappings GetApplicationMappings()

--- a/src/Steeltoe.Management.EndpointWeb/Handler/CloudFoundryCorsHandler.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Handler/CloudFoundryCorsHandler.cs
@@ -36,8 +36,8 @@ namespace Steeltoe.Management.Endpoint.Handler
 
         public override bool RequestVerbAndPathMatch(string httpMethod, string requestPath)
         {
-            _logger?.LogTrace("RequestVerbAndPathMatch {httpMethod}/{requestPath}/{optionsPath} request", httpMethod, requestPath, _options.Path);
-            return requestPath.StartsWith(_options.Path) && _allowedMethods.Any(m => m.Method.Equals(httpMethod));
+            _logger?.LogTrace("RequestVerbAndPathMatch {httpMethod}/{requestPath}/{optionsPath} request", httpMethod, requestPath, _options.FullPath);
+            return requestPath.StartsWith(_options.FullPath) && _allowedMethods.Any(m => m.Method.Equals(httpMethod));
         }
 
         public override void HandleRequest(HttpContext context)

--- a/src/Steeltoe.Management.EndpointWeb/Handler/MappingsHandler.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Handler/MappingsHandler.cs
@@ -44,8 +44,8 @@ namespace Steeltoe.Management.Endpoint.Handler
 
         public override bool RequestVerbAndPathMatch(string httpMethod, string requestPath)
         {
-            _logger?.LogTrace("RequestVerbAndPathMatch {httpMethod}/{requestPath}/{optionsPath} request", httpMethod, requestPath, _options.Path);
-            return requestPath.Equals(_options.Path) && _allowedMethods.Any(m => m.Method.Equals(httpMethod));
+            _logger?.LogTrace("RequestVerbAndPathMatch {httpMethod}/{requestPath}/{optionsPath} request", httpMethod, requestPath, _options.FullPath);
+            return requestPath.Equals(_options.FullPath) && _allowedMethods.Any(m => m.Method.Equals(httpMethod));
         }
 
         public async override Task<bool> IsAccessAllowed(HttpContext context)

--- a/test/Steeltoe.Management.EndpointBase.Test/AbstractOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/AbstractOptionsTest.cs
@@ -87,7 +87,7 @@ namespace Steeltoe.Management.Endpoint.Test
             Assert.True(opts.Enabled);
             Assert.False(opts.Sensitive);
             Assert.Equal("infomanagement", opts.Id);
-            Assert.Equal("/management/infomanagement", opts.Path);
+            Assert.Equal("/management/infomanagement", opts.FullPath);
             Assert.Equal(Permissions.NONE, opts.RequiredPermissions);
         }
 
@@ -115,7 +115,62 @@ namespace Steeltoe.Management.Endpoint.Test
             Assert.False(opts.Enabled);
             Assert.True(opts.Sensitive);
             Assert.Equal("infomanagement", opts.Id);
-            Assert.Equal("/management/infomanagement", opts.Path);
+            Assert.Equal("/management/infomanagement", opts.FullPath);
+        }
+
+        [Fact]
+        public void LocalPathWithGlobalPrefixConfigureCorrectly()
+        {
+            var appsettings = new Dictionary<string, string>()
+            {
+                ["management:endpoints:enabled"] = "false",
+                ["management:endpoints:sensitive"] = "true",
+                ["management:endpoints:path"] = "/management",
+                ["management:endpoints:info:path"] = "/info/endpoint",
+                ["management:endpoints:info:id"] = "infomanagement"
+            };
+            ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(appsettings);
+            var config = configurationBuilder.Build();
+
+            TestOptions2 opts = new TestOptions2("management:endpoints:info", config);
+
+            Assert.NotNull(opts.Global);
+            Assert.False(opts.Global.Enabled);
+            Assert.True(opts.Global.Sensitive);
+            Assert.Equal("/management", opts.Global.Path);
+
+            Assert.False(opts.Enabled);
+            Assert.True(opts.Sensitive);
+            Assert.Equal("infomanagement", opts.Id);
+            Assert.Equal("/management/info/endpoint", opts.FullPath);
+        }
+
+        [Fact]
+        public void LocalPathWithoutGlobalPrefixConfigureCorrectly()
+        {
+            var appsettings = new Dictionary<string, string>()
+            {
+                ["management:endpoints:enabled"] = "false",
+                ["management:endpoints:sensitive"] = "true",
+                ["management:endpoints:info:path"] = "/info/endpoint",
+                ["management:endpoints:info:id"] = "infomanagement"
+            };
+            ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(appsettings);
+            var config = configurationBuilder.Build();
+
+            TestOptions2 opts = new TestOptions2("management:endpoints:info", config);
+
+            Assert.NotNull(opts.Global);
+            Assert.False(opts.Global.Enabled);
+            Assert.True(opts.Global.Sensitive);
+            Assert.Equal("/", opts.Global.Path);
+
+            Assert.False(opts.Enabled);
+            Assert.True(opts.Sensitive);
+            Assert.Equal("infomanagement", opts.Id);
+            Assert.Equal("/info/endpoint", opts.FullPath);
         }
 
         [Fact]

--- a/test/Steeltoe.Management.EndpointBase.Test/CloudFoundry/CloudFoundryOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/CloudFoundry/CloudFoundryOptionsTest.cs
@@ -62,13 +62,13 @@ namespace Steeltoe.Management.Endpoint.CloudFoundry.Test
             Assert.True(cloudOpts.Enabled);
             Assert.False(cloudOpts.Sensitive);
             Assert.Equal(string.Empty, cloudOpts.Id);
-            Assert.Equal("/cloudfoundryapplication", cloudOpts.Path);
+            Assert.Equal("/cloudfoundryapplication", cloudOpts.FullPath);
             Assert.False(cloudOpts.ValidateCertificates);
 
             Assert.True(opts.Enabled);
             Assert.False(opts.Sensitive);
             Assert.Equal("info", opts.Id);
-            Assert.Equal("/cloudfoundryapplication/info", opts.Path);
+            Assert.Equal("/cloudfoundryapplication/info", opts.FullPath);
         }
     }
 }

--- a/test/Steeltoe.Management.EndpointBase.Test/Health/HealthOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Health/HealthOptionsTest.cs
@@ -65,13 +65,13 @@ namespace Steeltoe.Management.Endpoint.Health.Test
             Assert.True(cloudOpts.Enabled);
             Assert.False(cloudOpts.Sensitive);
             Assert.Equal(string.Empty, cloudOpts.Id);
-            Assert.Equal("/cloudfoundryapplication", cloudOpts.Path);
+            Assert.Equal("/cloudfoundryapplication", cloudOpts.FullPath);
             Assert.True(cloudOpts.ValidateCertificates);
 
             Assert.True(opts.Enabled);
             Assert.False(opts.Sensitive);
             Assert.Equal("health", opts.Id);
-            Assert.Equal("/cloudfoundryapplication/health", opts.Path);
+            Assert.Equal("/cloudfoundryapplication/health", opts.FullPath);
             Assert.Equal(Permissions.NONE, opts.RequiredPermissions);
         }
     }

--- a/test/Steeltoe.Management.EndpointBase.Test/HeapDump/HeapDumpOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/HeapDump/HeapDumpOptionsTest.cs
@@ -64,13 +64,13 @@ namespace Steeltoe.Management.Endpoint.HeapDump.Test
             Assert.True(cloudOpts.Enabled);
             Assert.False(cloudOpts.Sensitive);
             Assert.Equal(string.Empty, cloudOpts.Id);
-            Assert.Equal("/cloudfoundryapplication", cloudOpts.Path);
+            Assert.Equal("/cloudfoundryapplication", cloudOpts.FullPath);
             Assert.True(cloudOpts.ValidateCertificates);
 
             Assert.True(opts.Enabled);
             Assert.True(opts.Sensitive);
             Assert.Equal("heapdump", opts.Id);
-            Assert.Equal("/cloudfoundryapplication/heapdump", opts.Path);
+            Assert.Equal("/cloudfoundryapplication/heapdump", opts.FullPath);
         }
     }
 }

--- a/test/Steeltoe.Management.EndpointBase.Test/Loggers/LoggersOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Loggers/LoggersOptionsTest.cs
@@ -62,13 +62,13 @@ namespace Steeltoe.Management.Endpoint.Loggers.Test
             Assert.True(cloudOpts.Enabled);
             Assert.False(cloudOpts.Sensitive);
             Assert.Equal(string.Empty, cloudOpts.Id);
-            Assert.Equal("/cloudfoundryapplication", cloudOpts.Path);
+            Assert.Equal("/cloudfoundryapplication", cloudOpts.FullPath);
             Assert.True(cloudOpts.ValidateCertificates);
 
             Assert.False(opts.Enabled);
             Assert.True(opts.Sensitive);
             Assert.Equal("loggers", opts.Id);
-            Assert.Equal("/cloudfoundryapplication/loggers", opts.Path);
+            Assert.Equal("/cloudfoundryapplication/loggers", opts.FullPath);
         }
     }
 }

--- a/test/Steeltoe.Management.EndpointBase.Test/TestOptions.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/TestOptions.cs
@@ -26,7 +26,7 @@ namespace Steeltoe.Management.Endpoint.Test
 
         public IManagementOptions Global { get; set; }
 
-        public string Path { get; set; }
+        public string FullPath { get; set; }
 
         public Permissions RequiredPermissions { get; set; }
 

--- a/test/Steeltoe.Management.EndpointBase.Test/ThreadDump/ThreadDumpOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/ThreadDump/ThreadDumpOptionsTest.cs
@@ -64,13 +64,13 @@ namespace Steeltoe.Management.Endpoint.ThreadDump.Test
             Assert.True(cloudOpts.Enabled);
             Assert.False(cloudOpts.Sensitive);
             Assert.Equal(string.Empty, cloudOpts.Id);
-            Assert.Equal("/cloudfoundryapplication", cloudOpts.Path);
+            Assert.Equal("/cloudfoundryapplication", cloudOpts.FullPath);
             Assert.True(cloudOpts.ValidateCertificates);
 
             Assert.True(opts.Enabled);
             Assert.True(opts.Sensitive);
             Assert.Equal("dump", opts.Id);
-            Assert.Equal("/cloudfoundryapplication/dump", opts.Path);
+            Assert.Equal("/cloudfoundryapplication/dump", opts.FullPath);
         }
     }
 }

--- a/test/Steeltoe.Management.EndpointBase.Test/Trace/TraceOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Trace/TraceOptionsTest.cs
@@ -86,13 +86,13 @@ namespace Steeltoe.Management.Endpoint.Trace.Test
             Assert.True(cloudOpts.Enabled);
             Assert.False(cloudOpts.Sensitive);
             Assert.Equal(string.Empty, cloudOpts.Id);
-            Assert.Equal("/cloudfoundryapplication", cloudOpts.Path);
+            Assert.Equal("/cloudfoundryapplication", cloudOpts.FullPath);
             Assert.True(cloudOpts.ValidateCertificates);
 
             Assert.True(opts.Enabled);
             Assert.True(opts.Sensitive);
             Assert.Equal("trace", opts.Id);
-            Assert.Equal("/cloudfoundryapplication/trace", opts.Path);
+            Assert.Equal("/cloudfoundryapplication/trace", opts.FullPath);
             Assert.Equal(1000, opts.Capacity);
             Assert.False(opts.AddTimeTaken);
             Assert.False(opts.AddRequestHeaders);


### PR DESCRIPTION
The docs state that 

> The default path to the Health endpoint is /health, unless either the global or the **health endpoints path setting** has been changed.

This behavior is missing for all endpoints (not just Health). If `management:endpoints:health:path` is changed, it is ignored and the path to the endpoint still ends up being the global path prefix from settings + ID.

This PR changes the `Path` property of `AbstractOptions` to be the individual path to the endpoint (specified in `management:endpoints:{endpoint}:path`), which enables configuration binding to it. There is a new `FullPath` property which behaves as the full path to the endpoint described in the docs. This means that if `management:endpoints:health:path` is specified, the path to this endpoint will be `global prefix` + `path from options`, not `global prefix` + `ID`.

If the path for an endpoint is not specified in the settings, that endpoint's behavior is unchanged from the way it operates currently. All former references to `Path` now reference `FullPath`, which means the change is transparent to any code that was not previously using the individual endpoint path settings (which didn't work anyway).

I also added some tests for this since they were previously missing.
