### PR TITLE
Make Enable/Disable config settings functional

### DIFF
--- a/src/Steeltoe.Management.EndpointBase/Middleware/EndpointMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointBase/Middleware/EndpointMiddleware.cs
@@ -64,9 +64,10 @@ namespace Steeltoe.Management.Endpoint.Middleware
 
         public virtual bool RequestVerbAndPathMatch(string httpMethod, string requestPath)
         {
-            return _exactRequestPathMatching
-                ? requestPath.Equals(_endpoint.Path) && _allowedMethods.Any(m => m.Method.Equals(httpMethod))
-                : requestPath.StartsWith(_endpoint.Path) && _allowedMethods.Any(m => m.Method.Equals(httpMethod));
+            return (_exactRequestPathMatching ? requestPath.Equals(_endpoint.Path)
+              : requestPath.StartsWith(_endpoint.Path))
+                 && _endpoint.Enabled
+                 && _allowedMethods.Any(m => m.Method.Equals(httpMethod));
         }
 
         protected virtual string Serialize(TResult result)
@@ -110,9 +111,10 @@ namespace Steeltoe.Management.Endpoint.Middleware
 
         public override bool RequestVerbAndPathMatch(string httpMethod, string requestPath)
         {
-            return _exactRequestPathMatching
-                ? requestPath.Equals(_endpoint.Path) && _allowedMethods.Any(m => m.Method.Equals(httpMethod))
-                : requestPath.StartsWith(_endpoint.Path) && _allowedMethods.Any(m => m.Method.Equals(httpMethod));
+            return (_exactRequestPathMatching ? requestPath.Equals(_endpoint.Path)
+               : requestPath.StartsWith(_endpoint.Path))
+                  && _endpoint.Enabled
+                  && _allowedMethods.Any(m => m.Method.Equals(httpMethod));
         }
     }
 #pragma warning restore SA1402 // File may only contain a single class

--- a/test/Steeltoe.Management.EndpointCore.Test/Info/EndpointMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Info/EndpointMiddlewareTest.cs
@@ -34,7 +34,7 @@ namespace Steeltoe.Management.Endpoint.Info.Test
             ["management:endpoints:enabled"] = "false",
             ["management:endpoints:sensitive"] = "false",
             ["management:endpoints:path"] = "/management",
-            ["management:endpoints:info:enabled"] = "false",
+            ["management:endpoints:info:enabled"] = "true",
             ["management:endpoints:info:sensitive"] = "false",
             ["management:endpoints:info:id"] = "infomanagement",
             ["info:application:name"] = "foobar",


### PR DESCRIPTION
Currently enable/disable settings at global and individual enpoints are
not functional. Another way to achieve this is to not add the actuators.
This gives additional configuration based lever to control endpoints.

Addresses [#23]