### PR TITLE
Enable cross platform compilation of the solution.

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -4,5 +4,6 @@
     <add key="SteeltoeDev" value="https://www.myget.org/F/steeltoedev/api/v3/index.json" />
     <add key="OpenCensusDev" value="https://www.myget.org/F/opencensus/api/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+    <add key="DotnetCore" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/Steeltoe.Management.EndpointOwin/Info/InfoEndpointAppBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointOwin/Info/InfoEndpointAppBuilderExtensions.cs
@@ -19,6 +19,7 @@ using Steeltoe.Management.Endpoint.Info;
 using Steeltoe.Management.Endpoint.Info.Contributor;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net.Http;
 
 namespace Steeltoe.Management.EndpointOwin.Info
@@ -79,9 +80,10 @@ namespace Steeltoe.Management.EndpointOwin.Info
 
         private static IList<IInfoContributor> GetDefaultInfoContributors(IConfiguration config, ILoggerFactory loggerFactory = null)
         {
+            var gitInfoPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "git.properties");
             return new List<IInfoContributor>
                 {
-                    new GitInfoContributor(AppDomain.CurrentDomain.BaseDirectory + "\\git.properties", loggerFactory?.CreateLogger<GitInfoContributor>()),
+                    new GitInfoContributor(gitInfoPath, loggerFactory?.CreateLogger<GitInfoContributor>()),
                     new AppSettingsInfoContributor(config)
                 };
         }

--- a/src/Steeltoe.Management.EndpointOwin/Steeltoe.Management.EndpointOwin.csproj
+++ b/src/Steeltoe.Management.EndpointOwin/Steeltoe.Management.EndpointOwin.csproj
@@ -14,6 +14,9 @@
     <PackageProjectUrl>https://steeltoe.io</PackageProjectUrl>
     <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
   </PropertyGroup>
+
+  <Import Project="..\..\targetframework.props" />
+  
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Owin" Version="$(AspNetVersion)" />
     <PackageReference Include="Microsoft.Owin" Version="$(OwinVersion)" />

--- a/src/Steeltoe.Management.EndpointOwinAutofac/Steeltoe.Management.EndpointOwinAutofac.csproj
+++ b/src/Steeltoe.Management.EndpointOwinAutofac/Steeltoe.Management.EndpointOwinAutofac.csproj
@@ -14,6 +14,8 @@
     <PackageProjectUrl>https://steeltoe.io</PackageProjectUrl>
     <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
   </PropertyGroup>
+
+  <Import Project="..\..\targetframework.props" />
   
   <ItemGroup>
     <PackageReference Include="Autofac" Version="$(AutofacVersion)" />

--- a/src/Steeltoe.Management.EndpointWeb/Steeltoe.Management.EndpointWeb.csproj
+++ b/src/Steeltoe.Management.EndpointWeb/Steeltoe.Management.EndpointWeb.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\versions.props" />
-
+ 
   <PropertyGroup>
     <Description>Steeltoe Management Endpoints for ASP.NET 4.x</Description>
     <Authors>Pivotal;dtillman</Authors>
@@ -17,7 +17,7 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
   </PropertyGroup>
-
+  <Import Project="..\..\targetframework.props" />
   <PropertyGroup>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Steeltoe.Management.EndpointWeb.xml</DocumentationFile>
   </PropertyGroup>

--- a/targetframework.props
+++ b/targetframework.props
@@ -1,0 +1,10 @@
+<Project>
+    <PropertyGroup Condition="! $(OS.Contains('win')) AND '$(TargetFramework)'== 'net461'">
+        <FrameworkPathOverride>$(NuGetPackageRoot)microsoft.targetingpack.netframework.v4.6.1/1.0.1/lib/net461/</FrameworkPathOverride>
+        <RestoreAdditionalProjectSources>https://dotnet.myget.org/F/dotnet-core/api/v3/index.json</RestoreAdditionalProjectSources>
+    </PropertyGroup>
+    <ItemGroup Condition="! $(OS.Contains('win')) AND '$(TargetFramework)'== 'net461'">
+        <PackageReference Include="Microsoft.TargetingPack.NETFramework.v4.6.1"  Version="1.0.1" ExcludeAssets="All" PrivateAssets="All" />
+    </ItemGroup>
+</Project>
+

--- a/test/Steeltoe.Management.CloudFoundryCore.Test/Steeltoe.Management.CloudFoundryCore.Test.csproj
+++ b/test/Steeltoe.Management.CloudFoundryCore.Test/Steeltoe.Management.CloudFoundryCore.Test.csproj
@@ -4,6 +4,8 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;net461</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\targetframework.props" />
   
   <ItemGroup>
     <None Update="xunit.runner.json">

--- a/test/Steeltoe.Management.EndpointBase.Test/Env/EnvEndpointTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Env/EnvEndpointTest.cs
@@ -55,7 +55,7 @@ namespace Steeltoe.Management.Endpoint.Env.Test
             Assert.Equal(provider.GetType().Name, name);
 
             builder = new ConfigurationBuilder();
-            builder.AddJsonFile("c:\\foobar", true);
+            builder.AddJsonFile("foobar", true);
             config = builder.Build();
 
             ep = new EnvEndpoint(opts, config, new TestHosting());

--- a/test/Steeltoe.Management.EndpointBase.Test/Steeltoe.Management.EndpointBase.Test.csproj
+++ b/test/Steeltoe.Management.EndpointBase.Test/Steeltoe.Management.EndpointBase.Test.csproj
@@ -12,7 +12,8 @@
     <PackageProjectUrl>http://steeltoe.io</PackageProjectUrl>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
   </PropertyGroup>
-  
+
+  <Import Project="..\..\targetframework.props" />
   
   <ItemGroup>
     <None Update="empty.git.properties">

--- a/test/Steeltoe.Management.EndpointBase.Test/TestOptions.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/TestOptions.cs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.Generic;
 using Steeltoe.Management.Endpoint.Security;
+using System.Collections.Generic;
 
 namespace Steeltoe.Management.Endpoint.Test
 {

--- a/test/Steeltoe.Management.EndpointCore.Test/Steeltoe.Management.EndpointCore.Test.csproj
+++ b/test/Steeltoe.Management.EndpointCore.Test/Steeltoe.Management.EndpointCore.Test.csproj
@@ -11,7 +11,8 @@
     <PackageProjectUrl>http://steeltoe.io</PackageProjectUrl>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
   </PropertyGroup>
-  
+
+  <Import Project="..\..\targetframework.props" />
   
   <ItemGroup>
     <None Update="empty.git.properties">

--- a/test/Steeltoe.Management.EndpointOwin.Test/Steeltoe.Management.EndpointOwin.Test.csproj
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Steeltoe.Management.EndpointOwin.Test.csproj
@@ -6,7 +6,9 @@
     <Description>Unit test project for Steeltoe.Management.EndpointOwin</Description>
     <TargetFrameworks>net461</TargetFrameworks>
   </PropertyGroup>
-    
+
+  <Import Project="..\..\targetframework.props" />
+  
   <ItemGroup>
     <None Update="empty.git.properties">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/test/Steeltoe.Management.EndpointOwinAutofac.Test/Steeltoe.Management.EndpointOwinAutofac.Test.csproj
+++ b/test/Steeltoe.Management.EndpointOwinAutofac.Test/Steeltoe.Management.EndpointOwinAutofac.Test.csproj
@@ -7,6 +7,14 @@
     <TargetFrameworks>net461</TargetFrameworks>
     <AssemblyName>Steeltoe.Management.EndpointAutofac.Test</AssemblyName>
   </PropertyGroup>
+
+  <PropertyGroup Condition="! $(OS.Contains('win')) AND '$(TargetFramework)'== 'net461'">
+    <FrameworkPathOverride>$(NuGetPackageRoot)microsoft.targetingpack.netframework.v4.6.1/1.0.1/lib/net461/</FrameworkPathOverride>
+    <RestoreAdditionalProjectSources>https://dotnet.myget.org/F/dotnet-core/api/v3/index.json</RestoreAdditionalProjectSources>
+  </PropertyGroup>
+  <ItemGroup Condition="! $(OS.Contains('win')) AND '$(TargetFramework)'== 'net461'">
+    <PackageReference Include="Microsoft.TargetingPack.NETFramework.v4.6.1"  Version="1.0.1" ExcludeAssets="All" PrivateAssets="All" />
+  </ItemGroup>
   
   <ItemGroup>
     <ProjectReference Include="..\..\src\Steeltoe.Management.EndpointOwinAutofac\Steeltoe.Management.EndpointOwinAutofac.csproj" />

--- a/test/Steeltoe.Management.ExporterBase.Test/Steeltoe.Management.ExporterBase.Test.csproj
+++ b/test/Steeltoe.Management.ExporterBase.Test/Steeltoe.Management.ExporterBase.Test.csproj
@@ -12,7 +12,8 @@
     <PackageProjectUrl>http://steeltoe.io</PackageProjectUrl>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
   </PropertyGroup>
- 
+
+  <Import Project="..\..\targetframework.props" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Steeltoe.Management.ExporterBase\Steeltoe.Management.ExporterBase.csproj" />

--- a/test/Steeltoe.Management.ExporterCore.Test/Steeltoe.Management.ExporterCore.Test.csproj
+++ b/test/Steeltoe.Management.ExporterCore.Test/Steeltoe.Management.ExporterCore.Test.csproj
@@ -12,7 +12,8 @@
     <PackageProjectUrl>http://steeltoe.io</PackageProjectUrl>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
   </PropertyGroup>
- 
+
+  <Import Project="..\..\targetframework.props" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Steeltoe.Management.ExporterCore\Steeltoe.Management.ExporterCore.csproj" />

--- a/test/Steeltoe.Management.OpenCensus.Test/Steeltoe.Management.OpenCensus.Test.csproj
+++ b/test/Steeltoe.Management.OpenCensus.Test/Steeltoe.Management.OpenCensus.Test.csproj
@@ -12,7 +12,8 @@
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     <RootNamespace>Steeltoe.Management.Census</RootNamespace>
   </PropertyGroup>
-  
+
+  <Import Project="..\..\targetframework.props" />
   
   <ItemGroup>
     <None Update="xunit.runner.json">

--- a/test/Steeltoe.Management.TracingBase.Test/Steeltoe.Management.TracingBase.Test.csproj
+++ b/test/Steeltoe.Management.TracingBase.Test/Steeltoe.Management.TracingBase.Test.csproj
@@ -12,8 +12,9 @@
     <PackageProjectUrl>http://steeltoe.io</PackageProjectUrl>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
   </PropertyGroup>
- 
 
+  <Import Project="..\..\targetframework.props" />
+  
   <ItemGroup>
     <ProjectReference Include="..\..\src\Steeltoe.Management.TracingBase\Steeltoe.Management.TracingBase.csproj" />
   </ItemGroup>

--- a/test/Steeltoe.Management.TracingCore.Test/Steeltoe.Management.TracingCore.Test.csproj
+++ b/test/Steeltoe.Management.TracingCore.Test/Steeltoe.Management.TracingCore.Test.csproj
@@ -12,8 +12,9 @@
     <PackageProjectUrl>http://steeltoe.io</PackageProjectUrl>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
   </PropertyGroup>
- 
 
+  <Import Project="..\..\targetframework.props" />
+  
   <ItemGroup>
     <ProjectReference Include="..\..\src\Steeltoe.Management.TracingCore\Steeltoe.Management.TracingCore.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Without a targeting pack running dotnet build on a mac/ubuntu will fail with a "Reference assemblies were not found".Adding these targeting pack will allow happy roundtripping between windows and mac or ubuntu.
See https://github.com/dotnet/sdk/issues/335 for more details