### PR TITLE
Allow management endpoints to respond to request outside CloudFoundry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -288,3 +288,9 @@ __pycache__/
 *.xsd.cs
 
 *.vscode
+
+# OSX 
+.DS_Store
+.AppleDouble
+.LSOverride
+

--- a/src/Steeltoe.Management.CloudFoundryCore/CloudFoundryApplicationBuilderExtensions.cs
+++ b/src/Steeltoe.Management.CloudFoundryCore/CloudFoundryApplicationBuilderExtensions.cs
@@ -22,6 +22,7 @@ using Steeltoe.Management.Endpoint.Mappings;
 using Steeltoe.Management.Endpoint.ThreadDump;
 using Steeltoe.Management.Endpoint.Trace;
 using System;
+using Steeltoe.Management.Endpoint.Security;
 
 namespace Steeltoe.Management.CloudFoundry
 {
@@ -41,6 +42,7 @@ namespace Steeltoe.Management.CloudFoundry
             });
 
             app.UseCloudFoundrySecurity();
+            app.UseEndpointSecurity();
             app.UseCloudFoundryActuator();
 
             if (Environment.OSVersion.Platform == PlatformID.Win32NT)

--- a/src/Steeltoe.Management.EndpointBase/AbstractEndpoint.cs
+++ b/src/Steeltoe.Management.EndpointBase/AbstractEndpoint.cs
@@ -35,8 +35,8 @@ namespace Steeltoe.Management.Endpoint
         public virtual bool Sensitive => options.Sensitive.Value;
 
         public virtual IEndpointOptions Options => options;
-        
-        public List<string> Paths => new List<string>(options.AltPaths);
+
+        public List<string> Paths => new List<string>(options.Paths);
     }
 
 #pragma warning disable SA1402 // File may only contain a single class

--- a/src/Steeltoe.Management.EndpointBase/AbstractEndpoint.cs
+++ b/src/Steeltoe.Management.EndpointBase/AbstractEndpoint.cs
@@ -35,16 +35,8 @@ namespace Steeltoe.Management.Endpoint
         public virtual bool Sensitive => options.Sensitive.Value;
 
         public virtual IEndpointOptions Options => options;
-
-        public List<string> Paths
-        {
-            get
-            {
-                var paths = new List<string>(options.AltPaths);
-                paths.Add(options.Path);
-                return paths;
-            }
-        }
+        
+        public List<string> Paths => new List<string>(options.AltPaths);
     }
 
 #pragma warning disable SA1402 // File may only contain a single class

--- a/src/Steeltoe.Management.EndpointBase/AbstractOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/AbstractOptions.cs
@@ -16,6 +16,8 @@ using Microsoft.Extensions.Configuration;
 using Steeltoe.Management.Endpoint.Security;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using Steeltoe.Management.EndpointBase;
 
 namespace Steeltoe.Management.Endpoint
 {
@@ -120,46 +122,46 @@ namespace Steeltoe.Management.Endpoint
         public virtual IManagementOptions Global { get; set; }
 
         public virtual string Id { get; set; }
+        
+        public List<string> AltIds { get; set; }
 
-        public virtual List<string> AltIds { get; set; }
+//        public virtual string Path
+//        {
+//            get
+//            {
+//                string path = Global.Path;
+//                if (string.IsNullOrEmpty(Id))
+//                {
+//                    return path;
+//                }
+//
+//                if (!path.EndsWith("/"))
+//                {
+//                    path = path + "/";
+//                }
+//
+//                return path + Id;
+//            }
+//        }
 
-        public virtual string Path
-        {
-            get
-            {
-                string path = Global.Path;
-                if (string.IsNullOrEmpty(Id))
-                {
-                    return path;
-                }
-
-                if (!path.EndsWith("/"))
-                {
-                    path = path + "/";
-                }
-
-                return path + Id;
-            }
-        }
 
         public virtual List<string> AltPaths
         {
             get
             {
-                List<string> altPaths = new List<string>();
-                string path = Global.Path;
-
-                if (!path.EndsWith("/"))
-                {
-                    path = path + "/";
-                }
-
-                AltIds?.ForEach(id => altPaths.Add(path + id));
-
-                return altPaths;
+                var ids = new List<string> {Id};
+                AltIds?.ForEach(id => ids.Add(id));
+                // Return a path for each combination of path and Id
+                var paths =  new List<string> {Global.Path, Global.CloudFoundryPath}
+                        .SelectMany(
+                             x => ids,
+                            (p, id) => p.AddPath(id))
+                        .ToList();
+                return paths; 
             }
         }
 
+       
         public Permissions RequiredPermissions { get; set; } = Permissions.UNDEFINED;
 
         public virtual bool IsAccessAllowed(Permissions permissions)

--- a/src/Steeltoe.Management.EndpointBase/AbstractOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/AbstractOptions.cs
@@ -14,10 +14,10 @@
 
 using Microsoft.Extensions.Configuration;
 using Steeltoe.Management.Endpoint.Security;
+using Steeltoe.Management.EndpointBase;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Steeltoe.Management.EndpointBase;
 
 namespace Steeltoe.Management.Endpoint
 {
@@ -122,46 +122,25 @@ namespace Steeltoe.Management.Endpoint
         public virtual IManagementOptions Global { get; set; }
 
         public virtual string Id { get; set; }
-        
+
         public List<string> AltIds { get; set; }
 
-//        public virtual string Path
-//        {
-//            get
-//            {
-//                string path = Global.Path;
-//                if (string.IsNullOrEmpty(Id))
-//                {
-//                    return path;
-//                }
-//
-//                if (!path.EndsWith("/"))
-//                {
-//                    path = path + "/";
-//                }
-//
-//                return path + Id;
-//            }
-//        }
-
-
-        public virtual List<string> AltPaths
+        public virtual List<string> Paths
         {
             get
             {
-                var ids = new List<string> {Id};
-                AltIds?.ForEach(id => ids.Add(id));
+                var basePaths = new List<string> { Global.Path, Global.CloudFoundryPath };
+                var ids = new List<string>(AltIds ?? new List<string>()) { Id };
+
                 // Return a path for each combination of path and Id
-                var paths =  new List<string> {Global.Path, Global.CloudFoundryPath}
-                        .SelectMany(
-                             x => ids,
-                            (p, id) => p.AddPath(id))
-                        .ToList();
-                return paths; 
+                var paths = basePaths.SelectMany(
+                        x => ids,
+                        (p, id) => p.AddPath(id))
+                    .Distinct().ToList();
+                return paths;
             }
         }
 
-       
         public Permissions RequiredPermissions { get; set; } = Permissions.UNDEFINED;
 
         public virtual bool IsAccessAllowed(Permissions permissions)

--- a/src/Steeltoe.Management.EndpointBase/CloudFoundry/CloudFoundryEndpoint.cs
+++ b/src/Steeltoe.Management.EndpointBase/CloudFoundry/CloudFoundryEndpoint.cs
@@ -14,6 +14,7 @@
 
 using Microsoft.Extensions.Logging;
 using System;
+using System.Collections.Generic;
 
 namespace Steeltoe.Management.Endpoint.CloudFoundry
 {
@@ -57,18 +58,24 @@ namespace Steeltoe.Management.Endpoint.CloudFoundry
                 }
                 else
                 {
-                    if (!string.IsNullOrEmpty(opt.Id) && !links._links.ContainsKey(opt.Id))
+                    var ids = new List<string> {opt.Id};
+                    opt.AltIds?.ForEach(id => ids.Add(id));
+                    ids.ForEach(id =>
                     {
-                        links._links.Add(opt.Id, new Link(baseUrl + "/" + opt.Id));
-                    }
-                    else if (links._links.ContainsKey(opt.Id))
-                    {
-                        _logger?.LogWarning("Duplicate endpoint id detected: {DuplicateEndpointId}", opt.Id);
-                    }
+                        if (!links._links.ContainsKey(id))
+                        {
+                            links._links.Add(id, new Link(baseUrl + "/" + id));
+                        }
+                        else
+                        {
+                            _logger?.LogWarning("Duplicate endpoint id detected: {DuplicateEndpointId}", id);
+                        }
+                    });
                 }
             }
 
             return links;
         }
+        
     }
 }

--- a/src/Steeltoe.Management.EndpointBase/CloudFoundry/SecurityBase.cs
+++ b/src/Steeltoe.Management.EndpointBase/CloudFoundry/SecurityBase.cs
@@ -50,7 +50,7 @@ namespace Steeltoe.Management.Endpoint.CloudFoundry
 
         public bool IsCloudFoundryRequest(string requestPath)
         {
-            bool startsWith = requestPath.StartsWith(_options.Path);
+            bool startsWith = requestPath.StartsWith(_options.Global.CloudFoundryPath);
             return startsWith;
         }
 

--- a/src/Steeltoe.Management.EndpointBase/Health/HealthOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Health/HealthOptions.cs
@@ -14,6 +14,7 @@
 
 using Microsoft.Extensions.Configuration;
 using Steeltoe.Management.Endpoint.Security;
+using System.Collections.Generic;
 
 namespace Steeltoe.Management.Endpoint.Health
 {
@@ -34,6 +35,11 @@ namespace Steeltoe.Management.Endpoint.Health
             if (string.IsNullOrEmpty(Id))
             {
                 Id = "health";
+            }
+            // Make health endpoint available for Cloud Foundry integration
+            else 
+            {
+                AltIds = new List<string> {"health"};
             }
 
             if (RequiredPermissions == Permissions.UNDEFINED)

--- a/src/Steeltoe.Management.EndpointBase/IEndpointOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/IEndpointOptions.cs
@@ -33,7 +33,7 @@ namespace Steeltoe.Management.Endpoint
 
         List<string> AltIds { get; }
 
-        List<string> AltPaths { get; }
+        List<string> Paths { get; }
 
         Permissions RequiredPermissions { get; }
 

--- a/src/Steeltoe.Management.EndpointBase/IEndpointOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/IEndpointOptions.cs
@@ -33,8 +33,6 @@ namespace Steeltoe.Management.Endpoint
 
         List<string> AltIds { get; }
 
-        string Path { get; }
-
         List<string> AltPaths { get; }
 
         Permissions RequiredPermissions { get; }

--- a/src/Steeltoe.Management.EndpointBase/IManagementOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/IManagementOptions.cs
@@ -27,6 +27,8 @@ namespace Steeltoe.Management.Endpoint
 
         string Path { get; }
 
+        string CloudFoundryPath { get;  }
+
         List<IEndpointOptions> EndpointOptions { get;  }
     }
 }

--- a/src/Steeltoe.Management.EndpointBase/Info/InfoOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Info/InfoOptions.cs
@@ -14,6 +14,7 @@
 
 using Microsoft.Extensions.Configuration;
 using Steeltoe.Management.Endpoint.Security;
+using System.Collections.Generic;
 
 namespace Steeltoe.Management.Endpoint.Info
 {
@@ -35,6 +36,12 @@ namespace Steeltoe.Management.Endpoint.Info
             {
                 Id = "info";
             }
+            // Make info endpoint available for Cloud Foundry integration
+            else 
+            {
+                AltIds = new List<string> {"info"};
+            }
+
 
             if (RequiredPermissions == Permissions.UNDEFINED)
             {

--- a/src/Steeltoe.Management.EndpointBase/ManagementOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/ManagementOptions.cs
@@ -23,7 +23,7 @@ namespace Steeltoe.Management.Endpoint
     public class ManagementOptions : IManagementOptions
     {
         internal static ManagementOptions _instance;
-        private const string DEFAULT_PATH = "/";
+        private const string DEFAULT_PATH = "/actuator";
         private const string MANAGEMENT_INFO_PREFIX = "management:endpoints";
 
         private bool? _enabled;
@@ -77,6 +77,8 @@ namespace Steeltoe.Management.Endpoint
         }
 
         public string Path { get; set; }
+
+        public string CloudFoundryPath => "/cloudfoundryapplication";
 
         public List<IEndpointOptions> EndpointOptions { get; set; }
 

--- a/src/Steeltoe.Management.EndpointBase/Mappings/MappingsOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Mappings/MappingsOptions.cs
@@ -14,6 +14,7 @@
 
 using Microsoft.Extensions.Configuration;
 using Steeltoe.Management.Endpoint.Security;
+using System.Collections.Generic;
 
 namespace Steeltoe.Management.Endpoint.Mappings
 {
@@ -34,6 +35,11 @@ namespace Steeltoe.Management.Endpoint.Mappings
             if (string.IsNullOrEmpty(Id))
             {
                 Id = "mappings";
+            } 
+            // Make mappings endpoint available for Cloud Foundry integration
+            else 
+            {
+                AltIds = new List<string> { "mappings" };
             }
 
             if (RequiredPermissions == Permissions.UNDEFINED)

--- a/src/Steeltoe.Management.EndpointBase/Middleware/EndpointMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointBase/Middleware/EndpointMiddleware.cs
@@ -64,6 +64,7 @@ namespace Steeltoe.Management.Endpoint.Middleware
 
         public virtual bool RequestVerbAndPathMatch(string httpMethod, string requestPath)
         {
+
             return PathMatches(_exactRequestPathMatching, _endpoint.Paths, requestPath)
                  && _endpoint.Enabled
                  && _allowedMethods.Any(m => m.Method.Equals(httpMethod));
@@ -118,8 +119,8 @@ namespace Steeltoe.Management.Endpoint.Middleware
         public override bool RequestVerbAndPathMatch(string httpMethod, string requestPath)
         {
             return PathMatches(_exactRequestPathMatching, _endpoint.Paths, requestPath)
-                  && _endpoint.Enabled
-                  && _allowedMethods.Any(m => m.Method.Equals(httpMethod));
+                   && _endpoint.Enabled
+                   && _allowedMethods.Any(m => m.Method.Equals(httpMethod));
         }
     }
 #pragma warning restore SA1402 // File may only contain a single class

--- a/src/Steeltoe.Management.EndpointBase/Middleware/EndpointMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointBase/Middleware/EndpointMiddleware.cs
@@ -64,7 +64,6 @@ namespace Steeltoe.Management.Endpoint.Middleware
 
         public virtual bool RequestVerbAndPathMatch(string httpMethod, string requestPath)
         {
-
             return PathMatches(_exactRequestPathMatching, _endpoint.Paths, requestPath)
                  && _endpoint.Enabled
                  && _allowedMethods.Any(m => m.Method.Equals(httpMethod));

--- a/src/Steeltoe.Management.EndpointBase/Utils.cs
+++ b/src/Steeltoe.Management.EndpointBase/Utils.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.IO;
 using System.IO.Compression;
+using System.Reflection.Metadata.Ecma335;
 using System.Threading.Tasks;
 
 namespace Steeltoe.Management.EndpointBase
@@ -93,5 +94,16 @@ namespace Steeltoe.Management.EndpointBase
 
             return null;
         }
+
+        public static string AddPath(this string segment, string other) 
+        {
+            if (string.IsNullOrEmpty(other))
+            {
+                return segment?.TrimEnd('/');
+            }
+            
+            return $"{segment?.TrimEnd('/')}/{other.TrimStart('/')}";
+        }
+
     }
 }

--- a/src/Steeltoe.Management.EndpointBase/Utils.cs
+++ b/src/Steeltoe.Management.EndpointBase/Utils.cs
@@ -95,15 +95,14 @@ namespace Steeltoe.Management.EndpointBase
             return null;
         }
 
-        public static string AddPath(this string segment, string other) 
+        public static string AddPath(this string segment, string other)
         {
             if (string.IsNullOrEmpty(other))
             {
                 return segment?.TrimEnd('/');
             }
-            
+
             return $"{segment?.TrimEnd('/')}/{other.TrimStart('/')}";
         }
-
     }
 }

--- a/src/Steeltoe.Management.EndpointCore/CloudFoundry/CloudFoundrySecurityMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointCore/CloudFoundry/CloudFoundrySecurityMiddleware.cs
@@ -42,6 +42,7 @@ namespace Steeltoe.Management.Endpoint.CloudFoundry
         public async Task Invoke(HttpContext context)
         {
             _logger.LogDebug("Invoke({0})", context.Request.Path.Value);
+
             if (Platform.IsCloudFoundry && _options.IsEnabled && _helper.IsCloudFoundryRequest(context.Request.Path))
             {
                 if (string.IsNullOrEmpty(_options.ApplicationId))
@@ -113,19 +114,7 @@ namespace Steeltoe.Management.Endpoint.CloudFoundry
         private IEndpointOptions FindTargetEndpoint(PathString path)
         {
             var configEndpoints = this._options.Global.EndpointOptions;
-            foreach (var ep in configEndpoints)
-            {
-               
-                 foreach (var p in ep.AltPaths)
-                {
-                    if (path.StartsWithSegments(new PathString(p)))
-                        return ep;
-                }
-
-            }
-
-            return null;
+            return configEndpoints.FirstOrDefault(ep => ep.Paths.Any(p => p.Equals(path.Value)));
         }
     }
 }
-

--- a/src/Steeltoe.Management.EndpointCore/CloudFoundry/CloudFoundrySecurityMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointCore/CloudFoundry/CloudFoundrySecurityMiddleware.cs
@@ -42,8 +42,6 @@ namespace Steeltoe.Management.Endpoint.CloudFoundry
         public async Task Invoke(HttpContext context)
         {
             _logger.LogDebug("Invoke({0})", context.Request.Path.Value);
-            _logger.LogDebug("CloudFoundrySecurityMiddleware invoke {0} {1} {2}", Platform.IsCloudFoundry, _options.IsEnabled, _base.IsCloudFoundryRequest(context.Request.Path));
-
             if (Platform.IsCloudFoundry && _options.IsEnabled && _helper.IsCloudFoundryRequest(context.Request.Path))
             {
                 if (string.IsNullOrEmpty(_options.ApplicationId))
@@ -74,8 +72,7 @@ namespace Steeltoe.Management.Endpoint.CloudFoundry
                 var sr = await GetPermissions(context);
                 if (sr.Code != HttpStatusCode.OK)
                 {
-                    _logger.LogDebug("CloudFoundrySecurityMiddleware failed  permissions {0}", sr.Code);
-		    await _helper.ReturnError(context, sr);
+                    await _helper.ReturnError(context, sr);
                     return;
                 }
 
@@ -131,3 +128,4 @@ namespace Steeltoe.Management.Endpoint.CloudFoundry
         }
     }
 }
+

--- a/src/Steeltoe.Management.EndpointCore/Mappings/MappingsEndpointMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointCore/Mappings/MappingsEndpointMiddleware.cs
@@ -102,7 +102,7 @@ namespace Steeltoe.Management.Endpoint.Mappings
            // PathString path = new PathString(_options.Path);
             // TODO : verify mappings
             return // context.Request.Path.Equals(path) || context.Request.Path.Equals(_options.CloudFoundryPath);
-                _options.AltPaths.Any(p => context.Request.Path.Equals(p));
+                _options.Paths.Any(p => context.Request.Path.Equals(p));
         }
 
         protected internal IDictionary<string, IList<MappingDescription>> GetMappingDescriptions(ApiDescriptionProviderContext apiContext)

--- a/src/Steeltoe.Management.EndpointCore/Mappings/MappingsEndpointMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointCore/Mappings/MappingsEndpointMiddleware.cs
@@ -23,6 +23,7 @@ using Microsoft.AspNetCore.Routing.Constraints;
 using Microsoft.Extensions.Logging;
 using Steeltoe.Management.Endpoint.Middleware;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Steeltoe.Management.Endpoint.Mappings
@@ -98,8 +99,10 @@ namespace Steeltoe.Management.Endpoint.Mappings
                 return false;
             }
 
-            PathString path = new PathString(_options.Path);
-            return context.Request.Path.Equals(path);
+           // PathString path = new PathString(_options.Path);
+            // TODO : verify mappings
+            return // context.Request.Path.Equals(path) || context.Request.Path.Equals(_options.CloudFoundryPath);
+                _options.AltPaths.Any(p => context.Request.Path.Equals(p));
         }
 
         protected internal IDictionary<string, IList<MappingDescription>> GetMappingDescriptions(ApiDescriptionProviderContext apiContext)

--- a/src/Steeltoe.Management.EndpointCore/Mappings/MappingsEndpointMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointCore/Mappings/MappingsEndpointMiddleware.cs
@@ -99,10 +99,7 @@ namespace Steeltoe.Management.Endpoint.Mappings
                 return false;
             }
 
-           // PathString path = new PathString(_options.Path);
-            // TODO : verify mappings
-            return // context.Request.Path.Equals(path) || context.Request.Path.Equals(_options.CloudFoundryPath);
-                _options.Paths.Any(p => context.Request.Path.Equals(p));
+             return _options.Paths.Any(p => context.Request.Path.Equals(p));
         }
 
         protected internal IDictionary<string, IList<MappingDescription>> GetMappingDescriptions(ApiDescriptionProviderContext apiContext)

--- a/src/Steeltoe.Management.EndpointCore/Security/SecurityMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointCore/Security/SecurityMiddleware.cs
@@ -44,16 +44,9 @@ namespace Steeltoe.Management.Endpoint.Security
             // is in cloudfoundry, is not a cloud foundry request && isEnabled
             if (Platform.IsCloudFoundry && _options.IsEnabled && !_helper.IsCloudFoundryRequest(context.Request.Path.Value))
             {
-                IEndpointOptions target = FindTargetEndpoint(context.Request.Path);
-                if (target == null)
-                {
-                    await _helper.ReturnError(
-                        context,
-                        new SecurityResult(HttpStatusCode.ServiceUnavailable, _helper.ENDPOINT_NOT_CONFIGURED_MESSAGE));
-                    return;
-                }
+                var target = FindTargetEndpoint(context.Request.Path);
 
-                if (target.IsSensitive && !HasSensitiveClaim(context))
+                if (target != null && target.IsSensitive && !HasSensitiveClaim(context))
                 {
                     await _helper.ReturnError(
                         context,
@@ -75,7 +68,7 @@ namespace Steeltoe.Management.Endpoint.Security
 
         private IEndpointOptions FindTargetEndpoint(PathString path)
         {
-            var configEndpoints = this._options.Global.EndpointOptions;
+            var configEndpoints = _options.Global.EndpointOptions;
             return configEndpoints.FirstOrDefault(ep => ep.Paths.Any(p => p.Equals(path.Value)));
         }
     }

--- a/src/Steeltoe.Management.EndpointCore/Steeltoe.Management.EndpointCore.csproj
+++ b/src/Steeltoe.Management.EndpointCore/Steeltoe.Management.EndpointCore.csproj
@@ -22,8 +22,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.Abstractions" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsVersion)" />
     <PackageReference Include="Steeltoe.Common.Http" Version="$(SteeltoeCommonVersion)" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="$(StyleCopVersion)">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/Steeltoe.Management.EndpointOwin/CloudFoundry/CloudFoundryEndpointOwinMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointOwin/CloudFoundry/CloudFoundryEndpointOwinMiddleware.cs
@@ -31,7 +31,7 @@ namespace Steeltoe.Management.EndpointOwin.CloudFoundry
 
         public override async Task Invoke(IOwinContext context)
         {
-            if (!IsCloudFoundryRequest(context))
+            if (!RequestAndPathMatch(context))
             {
                 await Next.Invoke(context);
             }
@@ -56,7 +56,7 @@ namespace Steeltoe.Management.EndpointOwin.CloudFoundry
             return scheme + "://" + request.Host.ToString() + request.Path.ToString();
         }
 
-        private bool IsCloudFoundryRequest(IOwinContext context)
+        private bool RequestAndPathMatch(IOwinContext context)
         {
             var methodMatch = context.Request.Method == "GET";
             var pathMatch = _endpoint.Paths.Any(ep => ep.Equals(context.Request.Path.Value));

--- a/src/Steeltoe.Management.EndpointOwin/CloudFoundry/CloudFoundrySecurityOwinMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointOwin/CloudFoundry/CloudFoundrySecurityOwinMiddleware.cs
@@ -19,6 +19,7 @@ using Steeltoe.Management.Endpoint;
 using Steeltoe.Management.Endpoint.CloudFoundry;
 using Steeltoe.Management.Endpoint.Security;
 using System;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 
@@ -125,8 +126,7 @@ namespace Steeltoe.Management.EndpointOwin.CloudFoundry
             var configEndpoints = this._options.Global.EndpointOptions;
             foreach (var ep in configEndpoints)
             {
-                PathString epPath = new PathString(ep.Path);
-                if (path.StartsWithSegments(epPath))
+                if (ep.AltPaths.Any(p => path.ToString().EndsWith(p)))
                 {
                     return ep;
                 }

--- a/src/Steeltoe.Management.EndpointOwin/CloudFoundry/CloudFoundrySecurityOwinMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointOwin/CloudFoundry/CloudFoundrySecurityOwinMiddleware.cs
@@ -124,15 +124,7 @@ namespace Steeltoe.Management.EndpointOwin.CloudFoundry
         private IEndpointOptions FindTargetEndpoint(PathString path)
         {
             var configEndpoints = this._options.Global.EndpointOptions;
-            foreach (var ep in configEndpoints)
-            {
-                if (ep.AltPaths.Any(p => path.ToString().EndsWith(p)))
-                {
-                    return ep;
-                }
-            }
-
-            return null;
+            return configEndpoints.FirstOrDefault(ep => ep.Paths.Any(p => p.Equals(path.Value)));
         }
     }
 }

--- a/src/Steeltoe.Management.EndpointOwin/Mappings/MappingsEndpointOwinMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointOwin/Mappings/MappingsEndpointOwinMiddleware.cs
@@ -57,8 +57,8 @@ namespace Steeltoe.Management.EndpointOwin.Mappings
 
         public override bool RequestVerbAndPathMatch(string httpMethod, string requestPath)
         {
-            _logger?.LogTrace("RequestVerbAndPathMatch {httpMethod}/{requestPath}/{optionsPath} request", httpMethod, requestPath, _options.AltPaths);
-            return _options.AltPaths.Any(p => requestPath.Equals(p)) && _allowedMethods.Any(m => m.Method.Equals(httpMethod));
+            _logger?.LogTrace("RequestVerbAndPathMatch {httpMethod}/{requestPath}/{optionsPath} request", httpMethod, requestPath, string.Join(", ", _options.Paths));
+            return _options.Paths.Any(p => requestPath.Equals(p)) && _allowedMethods.Any(m => m.Method.Equals(httpMethod));
         }
 
         protected internal ApplicationMappings GetApplicationMappings()

--- a/src/Steeltoe.Management.EndpointOwin/Mappings/MappingsEndpointOwinMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointOwin/Mappings/MappingsEndpointOwinMiddleware.cs
@@ -57,8 +57,8 @@ namespace Steeltoe.Management.EndpointOwin.Mappings
 
         public override bool RequestVerbAndPathMatch(string httpMethod, string requestPath)
         {
-            _logger?.LogTrace("RequestVerbAndPathMatch {httpMethod}/{requestPath}/{optionsPath} request", httpMethod, requestPath, _options.Path);
-            return requestPath.Equals(_options.Path) && _allowedMethods.Any(m => m.Method.Equals(httpMethod));
+            _logger?.LogTrace("RequestVerbAndPathMatch {httpMethod}/{requestPath}/{optionsPath} request", httpMethod, requestPath, _options.AltPaths);
+            return _options.AltPaths.Any(p => requestPath.Equals(p)) && _allowedMethods.Any(m => m.Method.Equals(httpMethod));
         }
 
         protected internal ApplicationMappings GetApplicationMappings()

--- a/src/Steeltoe.Management.EndpointOwin/Security/SecurityMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointOwin/Security/SecurityMiddleware.cs
@@ -14,9 +14,9 @@
 
 using Microsoft.Extensions.Logging;
 using Microsoft.Owin;
+using Steeltoe.Common;
 using Steeltoe.Management.Endpoint.CloudFoundry;
-using Steeltoe.Management.Endpoint.Middleware;
-using System;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 
@@ -40,7 +40,8 @@ namespace Steeltoe.Management.Endpoint.Security
         {
             _logger?.LogDebug("Invoke({0})", context.Request.Path.Value);
 
-            if (_helper.IsCloudFoundryRequest(context.Request.Path.Value) && _options.IsEnabled)
+            // is in cloudfoundry, is not a cloud foundry request && isEnabled
+            if (Platform.IsCloudFoundry && _options.IsEnabled && !_helper.IsCloudFoundryRequest(context.Request.Path.Value))
             {
                 IEndpointOptions target = FindTargetEndpoint(context.Request.Path);
                 if (target == null)
@@ -74,16 +75,7 @@ namespace Steeltoe.Management.Endpoint.Security
         private IEndpointOptions FindTargetEndpoint(PathString path)
         {
             var configEndpoints = this._options.Global.EndpointOptions;
-            foreach (var ep in configEndpoints)
-            {
-                PathString epPath = new PathString(ep.Path);
-               if (path.Value == ep.Path)
-                {
-                    return ep;
-                }
-            }
-
-            return null;
+            return configEndpoints.FirstOrDefault(ep => ep.Paths.Any(p => p.Equals(path.Value)));
         }
     }
 }

--- a/src/Steeltoe.Management.EndpointWeb/Handler/CloudFoundryCorsHandler.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Handler/CloudFoundryCorsHandler.cs
@@ -36,9 +36,9 @@ namespace Steeltoe.Management.Endpoint.Handler
 
         public override bool RequestVerbAndPathMatch(string httpMethod, string requestPath)
         {
-            _logger?.LogTrace("RequestVerbAndPathMatch {httpMethod}/{requestPath}/{optionsPath} request", httpMethod, requestPath, _options.AltPaths);
-            
-            return _options.AltPaths.Any(requestPath.StartsWith) && _allowedMethods.Any(m => m.Method.Equals(httpMethod));
+            _logger?.LogTrace("RequestVerbAndPathMatch {httpMethod}/{requestPath}/{optionsPath} request", httpMethod, requestPath, string.Join(",", _options.Paths));
+
+            return _options.Paths.Any(requestPath.StartsWith) && _allowedMethods.Any(m => m.Method.Equals(httpMethod));
         }
 
         public override void HandleRequest(HttpContextBase context)

--- a/src/Steeltoe.Management.EndpointWeb/Handler/CloudFoundryCorsHandler.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Handler/CloudFoundryCorsHandler.cs
@@ -36,8 +36,9 @@ namespace Steeltoe.Management.Endpoint.Handler
 
         public override bool RequestVerbAndPathMatch(string httpMethod, string requestPath)
         {
-            _logger?.LogTrace("RequestVerbAndPathMatch {httpMethod}/{requestPath}/{optionsPath} request", httpMethod, requestPath, _options.Path);
-            return requestPath.StartsWith(_options.Path) && _allowedMethods.Any(m => m.Method.Equals(httpMethod));
+            _logger?.LogTrace("RequestVerbAndPathMatch {httpMethod}/{requestPath}/{optionsPath} request", httpMethod, requestPath, _options.AltPaths);
+            
+            return _options.AltPaths.Any(requestPath.StartsWith) && _allowedMethods.Any(m => m.Method.Equals(httpMethod));
         }
 
         public override void HandleRequest(HttpContextBase context)

--- a/src/Steeltoe.Management.EndpointWeb/Handler/MappingsHandler.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Handler/MappingsHandler.cs
@@ -44,8 +44,8 @@ namespace Steeltoe.Management.Endpoint.Handler
 
         public override bool RequestVerbAndPathMatch(string httpMethod, string requestPath)
         {
-            _logger?.LogTrace("RequestVerbAndPathMatch {httpMethod}/{requestPath}/{optionsPath} request", httpMethod, requestPath, _options.Path);
-            return requestPath.Equals(_options.Path) && _allowedMethods.Any(m => m.Method.Equals(httpMethod));
+            _logger?.LogTrace("RequestVerbAndPathMatch {httpMethod}/{requestPath}/{optionsPath} request", httpMethod, requestPath, _options.AltPaths);
+            return _options.AltPaths.Any(requestPath.Equals) && _allowedMethods.Any(m => m.Method.Equals(httpMethod));
         }
 
         public async override Task<bool> IsAccessAllowed(HttpContextBase context)

--- a/src/Steeltoe.Management.EndpointWeb/Handler/MappingsHandler.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Handler/MappingsHandler.cs
@@ -44,8 +44,8 @@ namespace Steeltoe.Management.Endpoint.Handler
 
         public override bool RequestVerbAndPathMatch(string httpMethod, string requestPath)
         {
-            _logger?.LogTrace("RequestVerbAndPathMatch {httpMethod}/{requestPath}/{optionsPath} request", httpMethod, requestPath, _options.AltPaths);
-            return _options.AltPaths.Any(requestPath.Equals) && _allowedMethods.Any(m => m.Method.Equals(httpMethod));
+            _logger?.LogTrace("RequestVerbAndPathMatch {httpMethod}/{requestPath}/{optionsPath} request", httpMethod, requestPath, string.Join(", ", _options.Paths));
+            return _options.Paths.Any(requestPath.Equals) && _allowedMethods.Any(m => m.Method.Equals(httpMethod));
         }
 
         public async override Task<bool> IsAccessAllowed(HttpContextBase context)

--- a/src/Steeltoe.Management.EndpointWeb/Security/CloudFoundrySecurity.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Security/CloudFoundrySecurity.cs
@@ -38,7 +38,7 @@ namespace Steeltoe.Management.Endpoint.Security
         public async Task<bool> IsAccessAllowed(HttpContextBase context, IEndpointOptions target)
         {
             // if running on Cloud Foundry, security is enabled, the path starts with /cloudfoundryapplication...
-            if (Platform.IsCloudFoundry && _options.IsEnabled)
+            if (Platform.IsCloudFoundry && _options.IsEnabled && _base.IsCloudFoundryRequest(context.Request.Path))
             {
                 _logger?.LogTrace("Beginning Cloud Foundry Security Processing");
 

--- a/src/Steeltoe.Management.EndpointWeb/Security/EndpointSecurity.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Security/EndpointSecurity.cs
@@ -38,8 +38,9 @@ namespace Steeltoe.Management.Endpoint.Security
 
         public async Task<bool> IsAccessAllowed(HttpContextBase context, IEndpointOptions target)
         {
-           if (_helper.IsCloudFoundryRequest(context.Request.Path) && _options.IsEnabled)
-            {
+           // If its in cloudfoundry, is not a cloud foundry request && isEnabled
+           if (Platform.IsCloudFoundry && !_helper.IsCloudFoundryRequest(context.Request.Path) && _options.IsEnabled)
+           {
                 _logger?.LogTrace("Beginning Endpoint Security Processing");
 
                 var origin = context.Request.Headers.Get("Origin");

--- a/src/Steeltoe.Management.ExporterBase/Steeltoe.Management.ExporterBase.csproj
+++ b/src/Steeltoe.Management.ExporterBase/Steeltoe.Management.ExporterBase.csproj
@@ -23,7 +23,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    
     <PackageReference Include="OpenCensus" Version="$(OpenCensusVersion)" />
+
+   
     <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryBase" Version="$(SteeltoeConfigVersion)" />
     <PackageReference Include="Steeltoe.Common.Http" Version="$(SteeltoeCommonVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="$(StyleCopVersion)">

--- a/test/Steeltoe.Management.EndpointBase.Test/AbstractOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/AbstractOptionsTest.cs
@@ -77,7 +77,7 @@ namespace Steeltoe.Management.Endpoint.Test
             configurationBuilder.AddInMemoryCollection(appsettings);
             var config = configurationBuilder.Build();
 
-            TestOptions2 opts = new TestOptions2("management:endpoints:info", config);
+            var opts = new TestOptions2("management:endpoints:info", config);
 
             Assert.NotNull(opts.Global);
             Assert.False(opts.Global.Enabled);
@@ -87,7 +87,10 @@ namespace Steeltoe.Management.Endpoint.Test
             Assert.True(opts.Enabled);
             Assert.False(opts.Sensitive);
             Assert.Equal("infomanagement", opts.Id);
-            Assert.Collection(opts.AltPaths, path => path.Equals("/management/infomanagement"));
+            Assert.Collection(
+                opts.Paths,
+                path => path.Equals("/management/infomanagement"),
+                path => path.Equals("/cloudfoundryapplication/infomanagement"));
             Assert.Equal(Permissions.NONE, opts.RequiredPermissions);
         }
 
@@ -101,11 +104,12 @@ namespace Steeltoe.Management.Endpoint.Test
                 ["management:endpoints:path"] = "/management",
                 ["management:endpoints:info:id"] = "infomanagement"
             };
+
             ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
             configurationBuilder.AddInMemoryCollection(appsettings);
             var config = configurationBuilder.Build();
 
-            TestOptions2 opts = new TestOptions2("management:endpoints:info", config);
+            var opts = new TestOptions2("management:endpoints:info", config);
 
             Assert.NotNull(opts.Global);
             Assert.False(opts.Global.Enabled);
@@ -115,10 +119,11 @@ namespace Steeltoe.Management.Endpoint.Test
             Assert.False(opts.Enabled);
             Assert.True(opts.Sensitive);
             Assert.Equal("infomanagement", opts.Id);
-            //Assert.Equal("/management/infomanagement", opts.Path);
-            
-            Assert.Collection(opts.AltPaths, path => path.Equals("/management/infomanagement"));
-            
+
+            Assert.Collection(
+                opts.Paths,
+                path => path.Equals("/management/infomanagement"),
+                path => path.Equals("/cloudfoundryapplication/infomanagement"));
         }
 
         [Fact]

--- a/test/Steeltoe.Management.EndpointBase.Test/AbstractOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/AbstractOptionsTest.cs
@@ -31,7 +31,7 @@ namespace Steeltoe.Management.Endpoint.Test
             Assert.NotNull(opts.Global);
             Assert.False(opts.Global.Enabled.HasValue);
             Assert.False(opts.Global.Sensitive.HasValue);
-            Assert.Equal("/", opts.Global.Path);
+            Assert.Equal("/actuator", opts.Global.Path);
             Assert.Equal(Permissions.UNDEFINED, opts.RequiredPermissions);
         }
 
@@ -87,7 +87,7 @@ namespace Steeltoe.Management.Endpoint.Test
             Assert.True(opts.Enabled);
             Assert.False(opts.Sensitive);
             Assert.Equal("infomanagement", opts.Id);
-            Assert.Equal("/management/infomanagement", opts.Path);
+            Assert.Collection(opts.AltPaths, path => path.Equals("/management/infomanagement"));
             Assert.Equal(Permissions.NONE, opts.RequiredPermissions);
         }
 
@@ -115,7 +115,10 @@ namespace Steeltoe.Management.Endpoint.Test
             Assert.False(opts.Enabled);
             Assert.True(opts.Sensitive);
             Assert.Equal("infomanagement", opts.Id);
-            Assert.Equal("/management/infomanagement", opts.Path);
+            //Assert.Equal("/management/infomanagement", opts.Path);
+            
+            Assert.Collection(opts.AltPaths, path => path.Equals("/management/infomanagement"));
+            
         }
 
         [Fact]

--- a/test/Steeltoe.Management.EndpointBase.Test/CloudFoundry/CloudFoundryOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/CloudFoundry/CloudFoundryOptionsTest.cs
@@ -47,7 +47,7 @@ namespace Steeltoe.Management.Endpoint.CloudFoundry.Test
             {
                 ["management:endpoints:enabled"] = "false",
                 ["management:endpoints:sensitive"] = "false",
-                ["management:endpoints:path"] = "/cloudfoundryapplication",
+                ["management:endpoints:path"] = "/actuator",
                 ["management:endpoints:info:enabled"] = "true",
                 ["management:endpoints:cloudfoundry:validatecertificates"] = "false",
                 ["management:endpoints:cloudfoundry:enabled"] = "true"
@@ -62,13 +62,21 @@ namespace Steeltoe.Management.Endpoint.CloudFoundry.Test
             Assert.True(cloudOpts.Enabled);
             Assert.False(cloudOpts.Sensitive);
             Assert.Equal(string.Empty, cloudOpts.Id);
-            Assert.Equal("/cloudfoundryapplication", cloudOpts.Path);
+            Assert.Collection(
+                cloudOpts.AltPaths, 
+                path => path.Equals("/cloudfoundryapplication"),
+                path => path.Equals("/actuator"));
             Assert.False(cloudOpts.ValidateCertificates);
 
             Assert.True(opts.Enabled);
             Assert.False(opts.Sensitive);
             Assert.Equal("info", opts.Id);
-            Assert.Equal("/cloudfoundryapplication/info", opts.Path);
+            Assert.Collection(
+                opts.AltPaths, 
+                path => path.Equals("/cloudfoundryapplication/info"),
+                path => path.Equals("/actuator/info"));
+
+
         }
     }
 }

--- a/test/Steeltoe.Management.EndpointBase.Test/CloudFoundry/CloudFoundryOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/CloudFoundry/CloudFoundryOptionsTest.cs
@@ -63,7 +63,7 @@ namespace Steeltoe.Management.Endpoint.CloudFoundry.Test
             Assert.False(cloudOpts.Sensitive);
             Assert.Equal(string.Empty, cloudOpts.Id);
             Assert.Collection(
-                cloudOpts.AltPaths, 
+                cloudOpts.Paths,
                 path => path.Equals("/cloudfoundryapplication"),
                 path => path.Equals("/actuator"));
             Assert.False(cloudOpts.ValidateCertificates);
@@ -72,11 +72,9 @@ namespace Steeltoe.Management.Endpoint.CloudFoundry.Test
             Assert.False(opts.Sensitive);
             Assert.Equal("info", opts.Id);
             Assert.Collection(
-                opts.AltPaths, 
+                opts.Paths,
                 path => path.Equals("/cloudfoundryapplication/info"),
                 path => path.Equals("/actuator/info"));
-
-
         }
     }
 }

--- a/test/Steeltoe.Management.EndpointBase.Test/CloudFoundry/SecurityBaseTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/CloudFoundry/SecurityBaseTest.cs
@@ -25,8 +25,8 @@ namespace Steeltoe.Management.EndpointBase.Test.CloudFoundry
         {
             var securityBase = new SecurityBase(new CloudFoundryOptions(), null);
 
-            Assert.True(securityBase.IsCloudFoundryRequest("/"));
-            Assert.True(securityBase.IsCloudFoundryRequest("/badpath"));
+            Assert.True(securityBase.IsCloudFoundryRequest("/cloudfoundryapplication"));
+            Assert.True(securityBase.IsCloudFoundryRequest("/cloudfoundryapplication/badpath"));
         }
     }
 }

--- a/test/Steeltoe.Management.EndpointBase.Test/Health/HealthOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Health/HealthOptionsTest.cs
@@ -66,7 +66,7 @@ namespace Steeltoe.Management.Endpoint.Health.Test
             Assert.False(cloudOpts.Sensitive);
             Assert.Equal(string.Empty, cloudOpts.Id);
             Assert.Collection(
-                cloudOpts.AltPaths,
+                cloudOpts.Paths,
                 path => path.Equals("/cloudfoundryapplication"),
                 path => path.Equals("/actuator"));
             Assert.True(cloudOpts.ValidateCertificates);
@@ -75,7 +75,7 @@ namespace Steeltoe.Management.Endpoint.Health.Test
             Assert.False(opts.Sensitive);
             Assert.Equal("health", opts.Id);
             Assert.Collection(
-                opts.AltPaths, 
+                opts.Paths,
                 path => path.Equals("/cloudfoundryapplication/health"),
                 path => path.Equals("/actuator/health"));
             Assert.Equal(Permissions.NONE, opts.RequiredPermissions);

--- a/test/Steeltoe.Management.EndpointBase.Test/Health/HealthOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Health/HealthOptionsTest.cs
@@ -49,7 +49,7 @@ namespace Steeltoe.Management.Endpoint.Health.Test
             {
                 ["management:endpoints:enabled"] = "false",
                 ["management:endpoints:sensitive"] = "false",
-                ["management:endpoints:path"] = "/cloudfoundryapplication",
+                ["management:endpoints:path"] = "/actuator",
                 ["management:endpoints:health:enabled"] = "true",
                 ["management:endpoints:health:requiredPermissions"] = "NONE",
                 ["management:endpoints:cloudfoundry:validatecertificates"] = "true",
@@ -65,13 +65,19 @@ namespace Steeltoe.Management.Endpoint.Health.Test
             Assert.True(cloudOpts.Enabled);
             Assert.False(cloudOpts.Sensitive);
             Assert.Equal(string.Empty, cloudOpts.Id);
-            Assert.Equal("/cloudfoundryapplication", cloudOpts.Path);
+            Assert.Collection(
+                cloudOpts.AltPaths,
+                path => path.Equals("/cloudfoundryapplication"),
+                path => path.Equals("/actuator"));
             Assert.True(cloudOpts.ValidateCertificates);
 
             Assert.True(opts.Enabled);
             Assert.False(opts.Sensitive);
             Assert.Equal("health", opts.Id);
-            Assert.Equal("/cloudfoundryapplication/health", opts.Path);
+            Assert.Collection(
+                opts.AltPaths, 
+                path => path.Equals("/cloudfoundryapplication/health"),
+                path => path.Equals("/actuator/health"));
             Assert.Equal(Permissions.NONE, opts.RequiredPermissions);
         }
     }

--- a/test/Steeltoe.Management.EndpointBase.Test/HeapDump/HeapDumpOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/HeapDump/HeapDumpOptionsTest.cs
@@ -46,7 +46,7 @@ namespace Steeltoe.Management.Endpoint.HeapDump.Test
             {
                 ["management:endpoints:enabled"] = "false",
                 ["management:endpoints:sensitive"] = "false",
-                ["management:endpoints:path"] = "/cloudfoundryapplication",
+                ["management:endpoints:path"] = "/actuator",
                 ["management:endpoints:loggers:enabled"] = "false",
                 ["management:endpoints:loggers:sensitive"] = "true",
                 ["management:endpoints:heapdump:enabled"] = "true",
@@ -64,13 +64,19 @@ namespace Steeltoe.Management.Endpoint.HeapDump.Test
             Assert.True(cloudOpts.Enabled);
             Assert.False(cloudOpts.Sensitive);
             Assert.Equal(string.Empty, cloudOpts.Id);
-            Assert.Equal("/cloudfoundryapplication", cloudOpts.Path);
+            Assert.Collection(
+                cloudOpts.AltPaths,
+                path => path.Equals("/cloudfoundryapplication"),
+                path => path.Equals("/actuator"));
             Assert.True(cloudOpts.ValidateCertificates);
 
             Assert.True(opts.Enabled);
             Assert.True(opts.Sensitive);
             Assert.Equal("heapdump", opts.Id);
-            Assert.Equal("/cloudfoundryapplication/heapdump", opts.Path);
+            Assert.Collection(
+                opts.AltPaths, 
+                path => path.Equals("/cloudfoundryapplication/heapdump"),
+                path => path.Equals("/actuator/heapdump"));
         }
     }
 }

--- a/test/Steeltoe.Management.EndpointBase.Test/HeapDump/HeapDumpOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/HeapDump/HeapDumpOptionsTest.cs
@@ -65,7 +65,7 @@ namespace Steeltoe.Management.Endpoint.HeapDump.Test
             Assert.False(cloudOpts.Sensitive);
             Assert.Equal(string.Empty, cloudOpts.Id);
             Assert.Collection(
-                cloudOpts.AltPaths,
+                cloudOpts.Paths,
                 path => path.Equals("/cloudfoundryapplication"),
                 path => path.Equals("/actuator"));
             Assert.True(cloudOpts.ValidateCertificates);
@@ -74,7 +74,7 @@ namespace Steeltoe.Management.Endpoint.HeapDump.Test
             Assert.True(opts.Sensitive);
             Assert.Equal("heapdump", opts.Id);
             Assert.Collection(
-                opts.AltPaths, 
+                opts.Paths,
                 path => path.Equals("/cloudfoundryapplication/heapdump"),
                 path => path.Equals("/actuator/heapdump"));
         }

--- a/test/Steeltoe.Management.EndpointBase.Test/Loggers/LoggersOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Loggers/LoggersOptionsTest.cs
@@ -62,13 +62,17 @@ namespace Steeltoe.Management.Endpoint.Loggers.Test
             Assert.True(cloudOpts.Enabled);
             Assert.False(cloudOpts.Sensitive);
             Assert.Equal(string.Empty, cloudOpts.Id);
-            Assert.Equal("/cloudfoundryapplication", cloudOpts.Path);
+            //Assert.Equal("/cloudfoundryapplication", cloudOpts.Path);
+            
+            Assert.Collection(opts.AltPaths, path => path.Equals("/cloudfoundryapplication"));
             Assert.True(cloudOpts.ValidateCertificates);
 
             Assert.False(opts.Enabled);
             Assert.True(opts.Sensitive);
             Assert.Equal("loggers", opts.Id);
-            Assert.Equal("/cloudfoundryapplication/loggers", opts.Path);
+            //Assert.Equal("/cloudfoundryapplication/loggers", opts.Path);
+            
+            Assert.Collection(opts.AltPaths, path => path.Equals("/cloudfoundryapplication/loggers"));
         }
     }
 }

--- a/test/Steeltoe.Management.EndpointBase.Test/Loggers/LoggersOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Loggers/LoggersOptionsTest.cs
@@ -62,17 +62,13 @@ namespace Steeltoe.Management.Endpoint.Loggers.Test
             Assert.True(cloudOpts.Enabled);
             Assert.False(cloudOpts.Sensitive);
             Assert.Equal(string.Empty, cloudOpts.Id);
-            //Assert.Equal("/cloudfoundryapplication", cloudOpts.Path);
-            
-            Assert.Collection(opts.AltPaths, path => path.Equals("/cloudfoundryapplication"));
+            Assert.Collection(opts.Paths, path => path.Equals("/cloudfoundryapplication"));
             Assert.True(cloudOpts.ValidateCertificates);
 
             Assert.False(opts.Enabled);
             Assert.True(opts.Sensitive);
             Assert.Equal("loggers", opts.Id);
-            //Assert.Equal("/cloudfoundryapplication/loggers", opts.Path);
-            
-            Assert.Collection(opts.AltPaths, path => path.Equals("/cloudfoundryapplication/loggers"));
+            Assert.Collection(opts.Paths, path => path.Equals("/cloudfoundryapplication/loggers"));
         }
     }
 }

--- a/test/Steeltoe.Management.EndpointBase.Test/ManagementOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/ManagementOptionsTest.cs
@@ -27,7 +27,7 @@ namespace Steeltoe.Management.Endpoint.Test
             ManagementOptions opts = ManagementOptions.GetInstance();
             Assert.False(opts.Enabled.HasValue);
             Assert.False(opts.Sensitive.HasValue);
-            Assert.Equal("/", opts.Path);
+            Assert.Equal("/actuator", opts.Path);
         }
 
         [Fact]

--- a/test/Steeltoe.Management.EndpointBase.Test/TestOptions.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/TestOptions.cs
@@ -39,7 +39,7 @@ namespace Steeltoe.Management.Endpoint.Test
 
         public List<string> AltIds => throw new System.NotImplementedException();
 
-        public List<string> AltPaths => throw new System.NotImplementedException();
+        public List<string> Paths => throw new System.NotImplementedException();
 
         public bool IsAccessAllowed(Permissions permissions)
         {

--- a/test/Steeltoe.Management.EndpointBase.Test/TestOptions.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/TestOptions.cs
@@ -29,6 +29,8 @@ namespace Steeltoe.Management.Endpoint.Test
 
         public string Path { get; set; }
 
+        public string CloudFoundryPath { get; set; }
+
         public Permissions RequiredPermissions { get; set; }
 
         public bool IsEnabled => Enabled.Value;

--- a/test/Steeltoe.Management.EndpointBase.Test/ThreadDump/ThreadDumpOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/ThreadDump/ThreadDumpOptionsTest.cs
@@ -64,17 +64,16 @@ namespace Steeltoe.Management.Endpoint.ThreadDump.Test
             Assert.True(cloudOpts.Enabled);
             Assert.False(cloudOpts.Sensitive);
             Assert.Equal(string.Empty, cloudOpts.Id);
-           // Assert.Equal("/cloudfoundryapplication", cloudOpts.Path);
-            
-            Assert.Collection(opts.AltPaths, path => path.Equals("/cloudfoundryapplication"));
+            Assert.Collection(cloudOpts.Paths, path => path.Equals("/cloudfoundryapplication"));
             Assert.True(cloudOpts.ValidateCertificates);
 
             Assert.True(opts.Enabled);
             Assert.True(opts.Sensitive);
             Assert.Equal("threaddump", opts.Id);
-            //Assert.Equal("/cloudfoundryapplication/threaddump", opts.Path);
-            
-            Assert.Collection(opts.AltPaths, path => path.Equals("/cloudfoundryapplication/threaddump"));
+            Assert.Collection(
+                opts.Paths,
+                path => path.Equals("/cloudfoundryapplication/threaddump"),
+                path => path.Equals("/cloudfoundryapplication/dump"));
         }
     }
 }

--- a/test/Steeltoe.Management.EndpointBase.Test/ThreadDump/ThreadDumpOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/ThreadDump/ThreadDumpOptionsTest.cs
@@ -64,13 +64,17 @@ namespace Steeltoe.Management.Endpoint.ThreadDump.Test
             Assert.True(cloudOpts.Enabled);
             Assert.False(cloudOpts.Sensitive);
             Assert.Equal(string.Empty, cloudOpts.Id);
-            Assert.Equal("/cloudfoundryapplication", cloudOpts.Path);
+           // Assert.Equal("/cloudfoundryapplication", cloudOpts.Path);
+            
+            Assert.Collection(opts.AltPaths, path => path.Equals("/cloudfoundryapplication"));
             Assert.True(cloudOpts.ValidateCertificates);
 
             Assert.True(opts.Enabled);
             Assert.True(opts.Sensitive);
             Assert.Equal("threaddump", opts.Id);
-            Assert.Equal("/cloudfoundryapplication/threaddump", opts.Path);
+            //Assert.Equal("/cloudfoundryapplication/threaddump", opts.Path);
+            
+            Assert.Collection(opts.AltPaths, path => path.Equals("/cloudfoundryapplication/threaddump"));
         }
     }
 }

--- a/test/Steeltoe.Management.EndpointBase.Test/Trace/TraceOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Trace/TraceOptionsTest.cs
@@ -86,17 +86,13 @@ namespace Steeltoe.Management.Endpoint.Trace.Test
             Assert.True(cloudOpts.Enabled);
             Assert.False(cloudOpts.Sensitive);
             Assert.Equal(string.Empty, cloudOpts.Id);
-            //Assert.Equal("/cloudfoundryapplication", cloudOpts.Path);
-            
-            Assert.Collection(cloudOpts.AltPaths, path => path.Equals("/cloudfoundryapplication"));
+            Assert.Collection(cloudOpts.Paths, path => path.Equals("/cloudfoundryapplication"));
             Assert.True(cloudOpts.ValidateCertificates);
 
             Assert.True(opts.Enabled);
             Assert.True(opts.Sensitive);
             Assert.Equal("trace", opts.Id);
-            //Assert.Equal("/cloudfoundryapplication/trace", opts.Path);
-            
-            Assert.Collection(opts.AltPaths, path => path.Equals("/cloudfoundryapplication/trace"));
+            Assert.Collection(opts.Paths, path => path.Equals("/cloudfoundryapplication/trace"));
             Assert.Equal(1000, opts.Capacity);
             Assert.False(opts.AddTimeTaken);
             Assert.False(opts.AddRequestHeaders);

--- a/test/Steeltoe.Management.EndpointBase.Test/Trace/TraceOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Trace/TraceOptionsTest.cs
@@ -86,13 +86,17 @@ namespace Steeltoe.Management.Endpoint.Trace.Test
             Assert.True(cloudOpts.Enabled);
             Assert.False(cloudOpts.Sensitive);
             Assert.Equal(string.Empty, cloudOpts.Id);
-            Assert.Equal("/cloudfoundryapplication", cloudOpts.Path);
+            //Assert.Equal("/cloudfoundryapplication", cloudOpts.Path);
+            
+            Assert.Collection(cloudOpts.AltPaths, path => path.Equals("/cloudfoundryapplication"));
             Assert.True(cloudOpts.ValidateCertificates);
 
             Assert.True(opts.Enabled);
             Assert.True(opts.Sensitive);
             Assert.Equal("trace", opts.Id);
-            Assert.Equal("/cloudfoundryapplication/trace", opts.Path);
+            //Assert.Equal("/cloudfoundryapplication/trace", opts.Path);
+            
+            Assert.Collection(opts.AltPaths, path => path.Equals("/cloudfoundryapplication/trace"));
             Assert.Equal(1000, opts.Capacity);
             Assert.False(opts.AddTimeTaken);
             Assert.False(opts.AddRequestHeaders);

--- a/test/Steeltoe.Management.EndpointCore.Test/CloudFoundry/CloudFoundrySecurityMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/CloudFoundry/CloudFoundrySecurityMiddlewareTest.cs
@@ -51,13 +51,12 @@ namespace Steeltoe.Management.Endpoint.CloudFoundry.Test
         }
 
         [Fact]
-        public async void CloudFoundrySecurityMiddleware_ReturnsServiceUnavailable()
+        public async void CloudFoundrySecurityMiddleware_ReturnsExpected()
         {
             var appSettings = new Dictionary<string, string>()
             {
                 ["management:endpoints:enabled"] = "true",
                 ["management:endpoints:sensitive"] = "false",
-                ["management:endpoints:path"] = "/",
                 ["management:endpoints:info:enabled"] = "true",
                 ["management:endpoints:info:sensitive"] = "false",
                 ["info:application:name"] = "foobar",
@@ -77,36 +76,8 @@ namespace Steeltoe.Management.Endpoint.CloudFoundry.Test
             using (var server = new TestServer(builder))
             {
                 var client = server.CreateClient();
-                var result = await client.GetAsync("http://localhost/info");
-                Assert.Equal(HttpStatusCode.ServiceUnavailable, result.StatusCode);
-            }
-
-            var appSettings2 = new Dictionary<string, string>()
-            {
-                ["management:endpoints:enabled"] = "true",
-                ["management:endpoints:sensitive"] = "false",
-                ["management:endpoints:path"] = "/",
-                ["management:endpoints:info:enabled"] = "true",
-                ["management:endpoints:info:sensitive"] = "false",
-                ["info:application:name"] = "foobar",
-                ["info:application:version"] = "1.0.0",
-                ["info:application:date"] = "5/1/2008",
-                ["info:application:time"] = "8:30:52 AM",
-                ["info:NET:type"] = "Core",
-                ["info:NET:version"] = "2.0.0",
-                ["info:NET:ASPNET:type"] = "Core",
-                ["info:NET:ASPNET:version"] = "2.0.0",
-                ["vcap:application:application_id"] = "foobar"
-            };
-
-            var builder2 = new WebHostBuilder().UseStartup<StartupWithSecurity>()
-                .ConfigureAppConfiguration((builderContext, config) => config.AddInMemoryCollection(appSettings2));
-
-            using (var server = new TestServer(builder2))
-            {
-                var client = server.CreateClient();
-                var result = await client.GetAsync("http://localhost/info");
-                Assert.Equal(HttpStatusCode.ServiceUnavailable, result.StatusCode);
+                var result = await client.GetAsync("http://localhost/actuator/info");
+                Assert.Equal(HttpStatusCode.OK, result.StatusCode);
             }
 
             var appSettings3 = new Dictionary<string, string>()
@@ -135,7 +106,7 @@ namespace Steeltoe.Management.Endpoint.CloudFoundry.Test
             {
                 var client = server.CreateClient();
                 var result = await client.GetAsync("http://localhost/barfoo");
-                Assert.Equal(HttpStatusCode.ServiceUnavailable, result.StatusCode);
+                Assert.Equal(HttpStatusCode.NotFound, result.StatusCode);
             }
         }
 
@@ -168,7 +139,7 @@ namespace Steeltoe.Management.Endpoint.CloudFoundry.Test
             using (var server = new TestServer(builder))
             {
                 var client = server.CreateClient();
-                var result = await client.GetAsync("http://localhost/info");
+                var result = await client.GetAsync("http://localhost/cloudfoundryapplication/info");
                 Assert.Equal(HttpStatusCode.Unauthorized, result.StatusCode);
             }
         }

--- a/test/Steeltoe.Management.EndpointCore.Test/CloudFoundry/EndpointMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/CloudFoundry/EndpointMiddlewareTest.cs
@@ -16,6 +16,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Steeltoe.Management.Endpoint.Test;
 using System;
@@ -110,9 +111,9 @@ namespace Steeltoe.Management.Endpoint.CloudFoundry.Test
             var ep = new CloudFoundryEndpoint(opts);
             var middle = new CloudFoundryEndpointMiddleware(null, ep);
 
-            Assert.True(middle.RequestVerbAndPathMatch("GET", "/"));
-            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/"));
-            Assert.False(middle.RequestVerbAndPathMatch("GET", "/badpath"));
+            Assert.True(middle.RequestVerbAndPathMatch("GET", "/actuator"));
+            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/actuator"));
+            Assert.False(middle.RequestVerbAndPathMatch("GET", "/actuator/badpath"));
         }
 
         private HttpContext CreateRequest(string method, string path)

--- a/test/Steeltoe.Management.EndpointCore.Test/CloudFoundry/StartupCloudFoundryActuators.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/CloudFoundry/StartupCloudFoundryActuators.cs
@@ -1,0 +1,52 @@
+﻿// Copyright 2017 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Steeltoe.Management.Endpoint.Health;
+using Steeltoe.Management.Endpoint.HeapDump;
+using Steeltoe.Management.Endpoint.Info;
+using Steeltoe.Management.Endpoint.Mappings;
+
+namespace Steeltoe.Management.Endpoint.CloudFoundry.Test
+{
+    public class StartupCloudFoundryActuators
+    {
+        public StartupCloudFoundryActuators(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; set; }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddCloudFoundryActuator(Configuration);
+            services.AddInfoActuator(Configuration);
+            services.AddHealthActuator(Configuration);
+            services.AddMappingsActuator(Configuration);
+            services.AddHeapDumpActuator(Configuration);
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            app.UseCloudFoundryActuator();
+            app.UseInfoActuator();
+            app.UseHealthActuator();
+            app.UseMappingsActuator();
+            app.UseHeapDumpActuator();
+        }
+    }
+}

--- a/test/Steeltoe.Management.EndpointCore.Test/Env/EndpointMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Env/EndpointMiddlewareTest.cs
@@ -104,8 +104,8 @@ namespace Steeltoe.Management.Endpoint.Env.Test
             var ep = new EnvEndpoint(opts, config, host);
             var middle = new EnvEndpointMiddleware(null, ep);
 
-            Assert.True(middle.RequestVerbAndPathMatch("GET", "/env"));
-            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/env"));
+            Assert.True(middle.RequestVerbAndPathMatch("GET", "/actuator/env"));
+            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/actuator/env"));
             Assert.False(middle.RequestVerbAndPathMatch("GET", "/badpath"));
         }
 

--- a/test/Steeltoe.Management.EndpointCore.Test/Health/EndpointMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Health/EndpointMiddlewareTest.cs
@@ -148,8 +148,8 @@ namespace Steeltoe.Management.Endpoint.Health.Test
             var middle = new HealthEndpointMiddleware(null);
             middle.Endpoint = ep;
 
-            Assert.True(middle.RequestVerbAndPathMatch("GET", "/health"));
-            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/health"));
+            Assert.True(middle.RequestVerbAndPathMatch("GET", "/actuator/health"));
+            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/actuator/health"));
             Assert.False(middle.RequestVerbAndPathMatch("GET", "/badpath"));
         }
 

--- a/test/Steeltoe.Management.EndpointCore.Test/HeapDump/EndpointMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/HeapDump/EndpointMiddlewareTest.cs
@@ -113,9 +113,9 @@ namespace Steeltoe.Management.Endpoint.HeapDump.Test
             var ep = new HeapDumpEndpoint(opts, obs);
             var middle = new HeapDumpEndpointMiddleware(null, ep);
 
-            Assert.True(middle.RequestVerbAndPathMatch("GET", "/heapdump"));
-            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/heapdump"));
-            Assert.False(middle.RequestVerbAndPathMatch("GET", "/badpath"));
+            Assert.True(middle.RequestVerbAndPathMatch("GET", "/actuator/heapdump"));
+            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/actuator/heapdump"));
+            Assert.False(middle.RequestVerbAndPathMatch("GET", "/actuator/badpath"));
         }
 
         private HttpContext CreateRequest(string method, string path)

--- a/test/Steeltoe.Management.EndpointCore.Test/Info/EndpointMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Info/EndpointMiddlewareTest.cs
@@ -114,9 +114,9 @@ namespace Steeltoe.Management.Endpoint.Info.Test
             var ep = new InfoEndpoint(opts, contribs);
             var middle = new InfoEndpointMiddleware(null, ep);
 
-            Assert.True(middle.RequestVerbAndPathMatch("GET", "/info"));
-            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/info"));
-            Assert.False(middle.RequestVerbAndPathMatch("GET", "/badpath"));
+            Assert.True(middle.RequestVerbAndPathMatch("GET", "/actuator/info"));
+            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/actuator/info"));
+            Assert.False(middle.RequestVerbAndPathMatch("GET", "/actuator/badpath"));
         }
 
         private HttpContext CreateRequest(string method, string path)

--- a/test/Steeltoe.Management.EndpointCore.Test/Loggers/EndpointMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Loggers/EndpointMiddlewareTest.cs
@@ -152,13 +152,13 @@ namespace Steeltoe.Management.Endpoint.Loggers.Test
             var ep = new LoggersEndpoint(opts, (IDynamicLoggerProvider)null);
             var middle = new LoggersEndpointMiddleware(null, ep);
 
-            Assert.True(middle.RequestVerbAndPathMatch("GET", "/loggers"));
-            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/loggers"));
-            Assert.False(middle.RequestVerbAndPathMatch("GET", "/badpath"));
-            Assert.True(middle.RequestVerbAndPathMatch("POST", "/loggers"));
-            Assert.False(middle.RequestVerbAndPathMatch("POST", "/badpath"));
-            Assert.True(middle.RequestVerbAndPathMatch("POST", "/loggers/Foo.Bar.Class"));
-            Assert.False(middle.RequestVerbAndPathMatch("POST", "/badpath/Foo.Bar.Class"));
+            Assert.True(middle.RequestVerbAndPathMatch("GET", "/actuator/loggers"));
+            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/actuator/loggers"));
+            Assert.False(middle.RequestVerbAndPathMatch("GET", "/actuator/badpath"));
+            Assert.True(middle.RequestVerbAndPathMatch("POST", "/actuator/loggers"));
+            Assert.False(middle.RequestVerbAndPathMatch("POST", "/actuator/badpath"));
+            Assert.True(middle.RequestVerbAndPathMatch("POST", "/actuator/loggers/Foo.Bar.Class"));
+            Assert.False(middle.RequestVerbAndPathMatch("POST", "/actuator/badpath/Foo.Bar.Class"));
         }
 
         [Fact]

--- a/test/Steeltoe.Management.EndpointCore.Test/Mappings/EndpointMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Mappings/EndpointMiddlewareTest.cs
@@ -56,11 +56,11 @@ namespace Steeltoe.Management.Endpoint.Mappings.Test
             };
             var middle = new MappingsEndpointMiddleware(null, opts);
 
-            var context = CreateRequest("GET", "/mappings");
+            var context = CreateRequest("GET", "/actuator/mappings");
             Assert.True(middle.IsMappingsRequest(context));
-            var context2 = CreateRequest("PUT", "/mappings");
+            var context2 = CreateRequest("PUT", "/actuator/mappings");
             Assert.False(middle.IsMappingsRequest(context2));
-            var context3 = CreateRequest("GET", "/badpath");
+            var context3 = CreateRequest("GET", "/actuator/badpath");
             Assert.False(middle.IsMappingsRequest(context3));
         }
 

--- a/test/Steeltoe.Management.EndpointCore.Test/Metrics/MetricsEndpointMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Metrics/MetricsEndpointMiddlewareTest.cs
@@ -84,13 +84,13 @@ namespace Steeltoe.Management.Endpoint.Metrics.Test
             var ep = new MetricsEndpoint(opts, stats);
             var middle = new MetricsEndpointMiddleware(null, ep);
 
-            var context1 = CreateRequest("GET", "/metrics");
+            var context1 = CreateRequest("GET", "/actuator/metrics");
             Assert.Null(middle.GetMetricName(context1.Request));
 
-            var context2 = CreateRequest("GET", "/metrics/Foo.Bar.Class");
+            var context2 = CreateRequest("GET", "/actuator/metrics/Foo.Bar.Class");
             Assert.Equal("Foo.Bar.Class", middle.GetMetricName(context2.Request));
 
-            var context3 = CreateRequest("GET", "/metrics", "?tag=key:value&tag=key1:value1");
+            var context3 = CreateRequest("GET", "/actuator/metrics", "?tag=key:value&tag=key1:value1");
             Assert.Null(middle.GetMetricName(context3.Request));
         }
 
@@ -121,7 +121,7 @@ namespace Steeltoe.Management.Endpoint.Metrics.Test
             var ep = new MetricsEndpoint(opts, stats);
             var middle = new MetricsEndpointMiddleware(null, ep);
 
-            var context = CreateRequest("GET", "/metrics/foo.bar");
+            var context = CreateRequest("GET", "/actuator/metrics/foo.bar");
 
             await middle.HandleMetricsRequestAsync(context);
             Assert.Equal(404, context.Response.StatusCode);
@@ -140,7 +140,7 @@ namespace Steeltoe.Management.Endpoint.Metrics.Test
 
             var middle = new MetricsEndpointMiddleware(null, ep);
 
-            var context = CreateRequest("GET", "/metrics/test.test", "?tag=a:v1");
+            var context = CreateRequest("GET", "/actuator/metrics/test.test", "?tag=a:v1");
 
             await middle.HandleMetricsRequestAsync(context);
             Assert.Equal(200, context.Response.StatusCode);
@@ -159,14 +159,14 @@ namespace Steeltoe.Management.Endpoint.Metrics.Test
             var ep = new MetricsEndpoint(opts, stats);
             var middle = new MetricsEndpointMiddleware(null, ep);
 
-            Assert.True(middle.RequestVerbAndPathMatch("GET", "/metrics"));
-            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/metrics"));
-            Assert.False(middle.RequestVerbAndPathMatch("GET", "/badpath"));
-            Assert.False(middle.RequestVerbAndPathMatch("POST", "/metrics"));
-            Assert.False(middle.RequestVerbAndPathMatch("DELETE", "/metrics"));
-            Assert.True(middle.RequestVerbAndPathMatch("GET", "/metrics/Foo.Bar.Class"));
-            Assert.True(middle.RequestVerbAndPathMatch("GET", "/metrics/Foo.Bar.Class?tag=key:value&tag=key1:value1"));
-            Assert.True(middle.RequestVerbAndPathMatch("GET", "/metrics?tag=key:value&tag=key1:value1"));
+            Assert.True(middle.RequestVerbAndPathMatch("GET", "/actuator/metrics"));
+            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/actuator/metrics"));
+            Assert.False(middle.RequestVerbAndPathMatch("GET", "/actuator/badpath"));
+            Assert.False(middle.RequestVerbAndPathMatch("POST", "/actuator/metrics"));
+            Assert.False(middle.RequestVerbAndPathMatch("DELETE", "/actuator/metrics"));
+            Assert.True(middle.RequestVerbAndPathMatch("GET", "/actuator/metrics/Foo.Bar.Class"));
+            Assert.True(middle.RequestVerbAndPathMatch("GET", "/actuator/metrics/Foo.Bar.Class?tag=key:value&tag=key1:value1"));
+            Assert.True(middle.RequestVerbAndPathMatch("GET", "/actuator/metrics?tag=key:value&tag=key1:value1"));
         }
 
         private HttpContext CreateRequest(string method, string path, string query = null)

--- a/test/Steeltoe.Management.EndpointCore.Test/Refresh/EndpointMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Refresh/EndpointMiddlewareTest.cs
@@ -98,9 +98,9 @@ namespace Steeltoe.Management.Endpoint.Refresh.Test
             var ep = new RefreshEndpoint(opts, config);
             var middle = new RefreshEndpointMiddleware(null, ep);
 
-            Assert.True(middle.RequestVerbAndPathMatch("GET", "/refresh"));
-            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/refresh"));
-            Assert.False(middle.RequestVerbAndPathMatch("GET", "/badpath"));
+            Assert.True(middle.RequestVerbAndPathMatch("GET", "/actuator/refresh"));
+            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/actuator/refresh"));
+            Assert.False(middle.RequestVerbAndPathMatch("GET", "/actuator/badpath"));
         }
 
         private HttpContext CreateRequest(string method, string path)

--- a/test/Steeltoe.Management.EndpointCore.Test/Security/SecurityMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Security/SecurityMiddlewareTest.cs
@@ -16,6 +16,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Steeltoe.Management.Endpoint.Test;
+using System;
 using System.Collections.Generic;
 using System.Net;
 using Xunit;
@@ -24,6 +25,11 @@ namespace Steeltoe.Management.Endpoint.Security.Test
 {
     public class SecurityMiddlewareTest : BaseTest
     {
+        public SecurityMiddlewareTest()
+        {
+            Environment.SetEnvironmentVariable("VCAP_APPLICATION", "somestuff");
+        }
+
         [Fact]
         public async void SecurityMiddleWare_ReturnsOKWhenNotSensitive()
         {
@@ -36,7 +42,7 @@ namespace Steeltoe.Management.Endpoint.Security.Test
             using (var server = new TestServer(builder))
             {
                 var client = server.CreateClient();
-                var result = await client.GetAsync("http://localhost/info");
+                var result = await client.GetAsync("http://localhost/actuator/info");
                 Assert.Equal(HttpStatusCode.OK, result.StatusCode);
             }
         }
@@ -55,7 +61,7 @@ namespace Steeltoe.Management.Endpoint.Security.Test
                 var client = server.CreateClient();
                 client.DefaultRequestHeaders.Add("X-Test-Header", "value");
 
-                var result = await client.GetAsync("http://localhost/info");
+                var result = await client.GetAsync("http://localhost/actuator/info");
                 Assert.Equal(HttpStatusCode.OK, result.StatusCode);
             }
         }
@@ -72,7 +78,7 @@ namespace Steeltoe.Management.Endpoint.Security.Test
             using (var server = new TestServer(builder))
             {
                 var client = server.CreateClient();
-                var result = await client.GetAsync("http://localhost/info");
+                var result = await client.GetAsync("http://localhost/actuator/info");
                 Assert.Equal(HttpStatusCode.Unauthorized, result.StatusCode);
             }
         }
@@ -83,13 +89,13 @@ namespace Steeltoe.Management.Endpoint.Security.Test
             var builder = GetBuilder<Startup>(new Dictionary<string, string>()
             {
                 ["management:endpoints:enabled"] = "true",
-                ["management:endpoints:sensitive"] = "true"
+                ["management:endpoints:info:sensitive"] = "true"
             });
 
             using (var server = new TestServer(builder))
             {
                 var client = server.CreateClient();
-                var result = await client.GetAsync("http://localhost/info");
+                var result = await client.GetAsync("http://localhost/actuator/info");
                 Assert.Equal(HttpStatusCode.Unauthorized, result.StatusCode);
             }
         }
@@ -106,7 +112,7 @@ namespace Steeltoe.Management.Endpoint.Security.Test
             using (var server = new TestServer(builder))
             {
                 var client = server.CreateClient();
-                var result = await client.GetAsync("http://localhost/info");
+                var result = await client.GetAsync("http://localhost/actuator/info");
                 Assert.Equal(HttpStatusCode.OK, result.StatusCode);
             }
         }
@@ -126,7 +132,7 @@ namespace Steeltoe.Management.Endpoint.Security.Test
             {
                 var client = server.CreateClient();
                 client.DefaultRequestHeaders.Add("X-Test-Header", "value");
-                var result = await client.GetAsync("http://localhost/info");
+                var result = await client.GetAsync("http://localhost/actuator/info");
                 Assert.Equal(HttpStatusCode.OK, result.StatusCode);
             }
         }

--- a/test/Steeltoe.Management.EndpointCore.Test/ThreadDump/EndpointMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/ThreadDump/EndpointMiddlewareTest.cs
@@ -98,9 +98,9 @@ namespace Steeltoe.Management.Endpoint.ThreadDump.Test
             var ep = new ThreadDumpEndpoint(opts, obs);
             var middle = new ThreadDumpEndpointMiddleware(null, ep);
 
-            Assert.True(middle.RequestVerbAndPathMatch("GET", "/dump"));
-            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/dump"));
-            Assert.False(middle.RequestVerbAndPathMatch("GET", "/badpath"));
+            Assert.True(middle.RequestVerbAndPathMatch("GET", "/actuator/dump"));
+            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/actuator/dump"));
+            Assert.False(middle.RequestVerbAndPathMatch("GET", "/actuator/badpath"));
         }
 
         private HttpContext CreateRequest(string method, string path)

--- a/test/Steeltoe.Management.EndpointCore.Test/Trace/EndpointMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Trace/EndpointMiddlewareTest.cs
@@ -88,9 +88,9 @@ namespace Steeltoe.Management.Endpoint.Trace.Test
             var ep = new TraceEndpoint(opts, obs);
             var middle = new TraceEndpointMiddleware(null, ep);
 
-            Assert.True(middle.RequestVerbAndPathMatch("GET", "/trace"));
-            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/trace"));
-            Assert.False(middle.RequestVerbAndPathMatch("GET", "/badpath"));
+            Assert.True(middle.RequestVerbAndPathMatch("GET", "/actuator/trace"));
+            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/actuator/trace"));
+            Assert.False(middle.RequestVerbAndPathMatch("GET", "/actuator/badpath"));
         }
 
         private HttpContext CreateRequest(string method, string path)

--- a/test/Steeltoe.Management.EndpointOwin.Test/CloudFoundry/CloudFoundryEndpointOwinMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/CloudFoundry/CloudFoundryEndpointOwinMiddlewareTest.cs
@@ -32,7 +32,7 @@ namespace Steeltoe.Management.EndpointOwin.CloudFoundry.Test
         {
             // arrange
             var middle = new CloudFoundryEndpointOwinMiddleware(null, new TestCloudFoundryEndpoint(new CloudFoundryOptions()));
-            var context = OwinTestHelpers.CreateRequest("GET", "/");
+            var context = OwinTestHelpers.CreateRequest("GET", "/actuator");
 
             // act
             var json = await middle.InvokeAndReadResponse(context);
@@ -70,9 +70,9 @@ namespace Steeltoe.Management.EndpointOwin.CloudFoundry.Test
             var ep = new CloudFoundryEndpoint(opts);
             var middle = new CloudFoundryEndpointOwinMiddleware(null, ep);
 
-            Assert.True(middle.RequestVerbAndPathMatch("GET", "/"));
-            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/"));
-            Assert.False(middle.RequestVerbAndPathMatch("GET", "/badpath"));
+            Assert.True(middle.RequestVerbAndPathMatch("GET", "/actuator"));
+            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/actuator"));
+            Assert.False(middle.RequestVerbAndPathMatch("GET", "/actuator/badpath"));
         }
     }
 }

--- a/test/Steeltoe.Management.EndpointOwin.Test/CloudFoundry/CloudFoundrySecurityMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/CloudFoundry/CloudFoundrySecurityMiddlewareTest.cs
@@ -38,7 +38,7 @@ namespace Steeltoe.Management.EndpointOwin.CloudFoundry.Test
             using (var server = TestServer.Create<StartupWithSecurity>())
             {
                 var client = server.HttpClient;
-                var result = await client.GetAsync("http://localhost/info");
+                var result = await client.GetAsync("http://localhost/cloudfoundryapplication/info");
                 Assert.Equal(HttpStatusCode.ServiceUnavailable, result.StatusCode);
                 var response = await result.Content.ReadAsStringAsync();
                 Assert.Contains(_base.APPLICATION_ID_MISSING_MESSAGE, response);
@@ -48,7 +48,7 @@ namespace Steeltoe.Management.EndpointOwin.CloudFoundry.Test
             using (var server = TestServer.Create<StartupWithSecurity>())
             {
                 var client = server.HttpClient;
-                var result = await client.GetAsync("http://localhost/info");
+                var result = await client.GetAsync("http://localhost/cloudfoundryapplication/info");
                 Assert.Equal(HttpStatusCode.ServiceUnavailable, result.StatusCode);
                 var response = await result.Content.ReadAsStringAsync();
                 Assert.Contains(_base.CLOUDFOUNDRY_API_MISSING_MESSAGE, response);
@@ -58,7 +58,7 @@ namespace Steeltoe.Management.EndpointOwin.CloudFoundry.Test
             using (var server = TestServer.Create<StartupWithSecurity>())
             {
                 var client = server.HttpClient;
-                var result = await client.GetAsync("http://localhost/barfoo");
+                var result = await client.GetAsync("http://localhost/cloudfoundryapplication/barfoo");
                 Assert.Equal(HttpStatusCode.ServiceUnavailable, result.StatusCode);
                 var response = await result.Content.ReadAsStringAsync();
                 Assert.Contains(_base.ENDPOINT_NOT_CONFIGURED_MESSAGE, response);
@@ -74,7 +74,7 @@ namespace Steeltoe.Management.EndpointOwin.CloudFoundry.Test
             using (var server = TestServer.Create<StartupWithSecurity>())
             {
                 var client = server.HttpClient;
-                var result = await client.GetAsync("http://localhost/info");
+                var result = await client.GetAsync("http://localhost/cloudfoundryapplication/info");
                 Assert.Equal(HttpStatusCode.Unauthorized, result.StatusCode);
                 var response = await result.Content.ReadAsStringAsync();
                 Assert.Contains(_base.AUTHORIZATION_HEADER_INVALID, response);

--- a/test/Steeltoe.Management.EndpointOwin.Test/Env/EnvOwinMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Env/EnvOwinMiddlewareTest.cs
@@ -33,7 +33,7 @@ namespace Steeltoe.Management.EndpointOwin.Env.Test
             var config = configurationBuilder.Build();
             var ep = new EnvEndpoint(new EnvOptions(), config, new GenericHostingEnvironment() { EnvironmentName = "EnvironmentName" });
             var middle = new EndpointOwinMiddleware<EnvironmentDescriptor>(null, ep);
-            var context = OwinTestHelpers.CreateRequest("GET", "/env");
+            var context = OwinTestHelpers.CreateRequest("GET", "/actuator/env");
 
             // act
             var json = await middle.InvokeAndReadResponse(context);
@@ -70,9 +70,9 @@ namespace Steeltoe.Management.EndpointOwin.Env.Test
             var ep = new EnvEndpoint(opts, config, host);
             var middle = new EndpointOwinMiddleware<EnvironmentDescriptor>(null, ep);
 
-            Assert.True(middle.RequestVerbAndPathMatch("GET", "/env"));
-            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/env"));
-            Assert.False(middle.RequestVerbAndPathMatch("GET", "/badpath"));
+            Assert.True(middle.RequestVerbAndPathMatch("GET", "/actuator/env"));
+            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/actuator/env"));
+            Assert.False(middle.RequestVerbAndPathMatch("GET", "/actuator/badpath"));
         }
     }
 }

--- a/test/Steeltoe.Management.EndpointOwin.Test/Health/HealthEndpointOwinMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Health/HealthEndpointOwinMiddlewareTest.cs
@@ -37,7 +37,7 @@ namespace Steeltoe.Management.EndpointOwin.Health.Test
             var contribs = new List<IHealthContributor>() { new DiskSpaceContributor() };
             var ep = new TestHealthEndpoint(opts, new DefaultHealthAggregator(), contribs);
             var middle = new HealthEndpointOwinMiddleware(null, ep);
-            var context = OwinTestHelpers.CreateRequest("GET", "/health");
+            var context = OwinTestHelpers.CreateRequest("GET", "/actuator/health");
 
             // act
             var json = await middle.InvokeAndReadResponse(context);
@@ -80,9 +80,9 @@ namespace Steeltoe.Management.EndpointOwin.Health.Test
             var ep = new HealthEndpoint(opts, new DefaultHealthAggregator(), contribs);
             var middle = new HealthEndpointOwinMiddleware(null, ep);
 
-            Assert.True(middle.RequestVerbAndPathMatch("GET", "/health"));
-            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/health"));
-            Assert.False(middle.RequestVerbAndPathMatch("GET", "/badpath"));
+            Assert.True(middle.RequestVerbAndPathMatch("GET", "/actuator/health"));
+            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/actuator/health"));
+            Assert.False(middle.RequestVerbAndPathMatch("GET", "/actuator/badpath"));
         }
 
         private async Task<Dictionary<string, object>> AssertHealthResponseAsync(HttpStatusCode expectedHttpStatus, HealthStatus expectedHealthStatus, HttpResponseMessage response)

--- a/test/Steeltoe.Management.EndpointOwin.Test/HeapDump/HeapDumpEndpointOwinMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/HeapDump/HeapDumpEndpointOwinMiddlewareTest.cs
@@ -42,7 +42,7 @@ namespace Steeltoe.Management.EndpointOwin.HeapDump.Test
                 HeapDumper obs = new HeapDumper(opts, logger: logger1);
                 var ep = new HeapDumpEndpoint(opts, obs, logger2);
                 var middle = new HeapDumpEndpointOwinMiddleware(null, ep, logger3);
-                var context = OwinTestHelpers.CreateRequest("GET", "/heapdump", GetResponseBodyStream());
+                var context = OwinTestHelpers.CreateRequest("GET", "/actuator/heapdump", GetResponseBodyStream());
                 await middle.Invoke(context);
                 context.Response.Body.Seek(0, SeekOrigin.Begin);
                 byte[] buffer = new byte[1024];
@@ -89,9 +89,9 @@ namespace Steeltoe.Management.EndpointOwin.HeapDump.Test
             var ep = new HeapDumpEndpoint(opts, obs);
             var middle = new HeapDumpEndpointOwinMiddleware(null, ep);
 
-            Assert.True(middle.RequestVerbAndPathMatch("GET", "/heapdump"));
-            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/heapdump"));
-            Assert.False(middle.RequestVerbAndPathMatch("GET", "/badpath"));
+            Assert.True(middle.RequestVerbAndPathMatch("GET", "/actuator/heapdump"));
+            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/actuator/heapdump"));
+            Assert.False(middle.RequestVerbAndPathMatch("GET", "/actuator/badpath"));
         }
 
         private Stream GetResponseBodyStream()

--- a/test/Steeltoe.Management.EndpointOwin.Test/Info/InfoEndpointOwinMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Info/InfoEndpointOwinMiddlewareTest.cs
@@ -32,7 +32,7 @@ namespace Steeltoe.Management.EndpointOwin.Info.Test
             // arrange
             var ep = new TestInfoEndpoint(new InfoOptions(), new List<IInfoContributor>() { new GitInfoContributor() });
             var middle = new EndpointOwinMiddleware<Dictionary<string, object>>(null, ep);
-            var context = OwinTestHelpers.CreateRequest("GET", "/info");
+            var context = OwinTestHelpers.CreateRequest("GET", "/actuator/info");
 
             // act
             var json = await middle.InvokeAndReadResponse(context);
@@ -89,9 +89,9 @@ namespace Steeltoe.Management.EndpointOwin.Info.Test
             var ep = new InfoEndpoint(opts, contribs);
             var middle = new EndpointOwinMiddleware<Dictionary<string, object>>(null, ep);
 
-            Assert.True(middle.RequestVerbAndPathMatch("GET", "/info"));
-            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/info"));
-            Assert.False(middle.RequestVerbAndPathMatch("GET", "/badpath"));
+            Assert.True(middle.RequestVerbAndPathMatch("GET", "/actuator/info"));
+            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/actuator/info"));
+            Assert.False(middle.RequestVerbAndPathMatch("GET", "/actuator/badpath"));
         }
     }
 }

--- a/test/Steeltoe.Management.EndpointOwin.Test/Loggers/LoggersEndpointOwinMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Loggers/LoggersEndpointOwinMiddlewareTest.cs
@@ -33,7 +33,7 @@ namespace Steeltoe.Management.EndpointOwin.Loggers.Test
         {
             var ep = new TestLoggersEndpoint(new LoggersOptions());
             var middle = new LoggersEndpointOwinMiddleware(null, ep);
-            var context = OwinTestHelpers.CreateRequest("GET", "/loggers");
+            var context = OwinTestHelpers.CreateRequest("GET", "/actuator/loggers");
             await middle.Invoke(context);
             context.Response.Body.Seek(0, SeekOrigin.Begin);
             StreamReader rdr = new StreamReader(context.Response.Body);
@@ -111,13 +111,13 @@ namespace Steeltoe.Management.EndpointOwin.Loggers.Test
             var ep = new LoggersEndpoint(opts, (IDynamicLoggerProvider)null);
             var middle = new LoggersEndpointOwinMiddleware(null, ep);
 
-            Assert.True(middle.RequestVerbAndPathMatch("GET", "/loggers"));
-            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/loggers"));
-            Assert.False(middle.RequestVerbAndPathMatch("GET", "/badpath"));
-            Assert.True(middle.RequestVerbAndPathMatch("POST", "/loggers"));
-            Assert.False(middle.RequestVerbAndPathMatch("POST", "/badpath"));
-            Assert.True(middle.RequestVerbAndPathMatch("POST", "/loggers/Foo.Bar.Class"));
-            Assert.False(middle.RequestVerbAndPathMatch("POST", "/badpath/Foo.Bar.Class"));
+            Assert.True(middle.RequestVerbAndPathMatch("GET", "/actuator/loggers"));
+            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/actuator/loggers"));
+            Assert.False(middle.RequestVerbAndPathMatch("GET", "/actuator/badpath"));
+            Assert.True(middle.RequestVerbAndPathMatch("POST", "/actuator/loggers"));
+            Assert.False(middle.RequestVerbAndPathMatch("POST", "/actuator/badpath"));
+            Assert.True(middle.RequestVerbAndPathMatch("POST", "/actuator/loggers/Foo.Bar.Class"));
+            Assert.False(middle.RequestVerbAndPathMatch("POST", "/actuator/badpath/Foo.Bar.Class"));
         }
     }
 }

--- a/test/Steeltoe.Management.EndpointOwin.Test/Metrics/MetricsEndpointOwinMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Metrics/MetricsEndpointOwinMiddlewareTest.cs
@@ -52,24 +52,24 @@ namespace Steeltoe.Management.EndpointOwin.Metrics.Test
             var ep = new MetricsEndpoint(opts, stats);
             var middle = new MetricsEndpointOwinMiddleware(null, ep);
 
-            var context1 = CreateRequest("GET", "/metrics/Foo.Bar.Class", "foo=key:value");
+            var context1 = CreateRequest("GET", "/actuator/metrics/Foo.Bar.Class", "foo=key:value");
             var result = middle.ParseTags(context1.Request.Query);
             Assert.NotNull(result);
             Assert.Empty(result);
 
-            var context2 = CreateRequest("GET", "/metrics/Foo.Bar.Class", "tag=key:value");
+            var context2 = CreateRequest("GET", "/actuator/metrics/Foo.Bar.Class", "tag=key:value");
             result = middle.ParseTags(context2.Request.Query);
             Assert.NotNull(result);
             Assert.Contains(new KeyValuePair<string, string>("key", "value"), result);
 
-            var context3 = CreateRequest("GET", "/metrics/Foo.Bar.Class", "tag=key:value&foo=key:value&tag=key1:value1");
+            var context3 = CreateRequest("GET", "/actuator/metrics/Foo.Bar.Class", "tag=key:value&foo=key:value&tag=key1:value1");
             result = middle.ParseTags(context3.Request.Query);
             Assert.NotNull(result);
             Assert.Contains(new KeyValuePair<string, string>("key", "value"), result);
             Assert.Contains(new KeyValuePair<string, string>("key1", "value1"), result);
             Assert.Equal(2, result.Count);
 
-            var context4 = CreateRequest("GET", "/metrics/Foo.Bar.Class", "tag=key:value&foo=key:value&tag=key:value");
+            var context4 = CreateRequest("GET", "/actuator/metrics/Foo.Bar.Class", "tag=key:value&foo=key:value&tag=key:value");
             result = middle.ParseTags(context4.Request.Query);
             Assert.NotNull(result);
             Assert.Contains(new KeyValuePair<string, string>("key", "value"), result);
@@ -85,13 +85,13 @@ namespace Steeltoe.Management.EndpointOwin.Metrics.Test
             var ep = new MetricsEndpoint(opts, stats);
             var middle = new MetricsEndpointOwinMiddleware(null, ep);
 
-            var context1 = CreateRequest("GET", "/metrics");
+            var context1 = CreateRequest("GET", "/actuator/actuator/metrics");
             Assert.Null(middle.GetMetricName(context1.Request));
 
-            var context2 = CreateRequest("GET", "/metrics/Foo.Bar.Class");
+            var context2 = CreateRequest("GET", "/actuator/metrics/Foo.Bar.Class");
             Assert.Equal("Foo.Bar.Class", middle.GetMetricName(context2.Request));
 
-            var context3 = CreateRequest("GET", "/metrics", "tag=key:value&tag=key1:value1");
+            var context3 = CreateRequest("GET", "/actuator/metrics", "tag=key:value&tag=key1:value1");
             Assert.Null(middle.GetMetricName(context3.Request));
         }
 
@@ -104,7 +104,7 @@ namespace Steeltoe.Management.EndpointOwin.Metrics.Test
             var ep = new MetricsEndpoint(opts, stats);
             var middle = new MetricsEndpointOwinMiddleware(null, ep);
 
-            var context = CreateRequest("GET", "/metrics");
+            var context = CreateRequest("GET", "/actuator/metrics");
 
             await middle.HandleMetricsRequestAsync(context);
             context.Response.Body.Seek(0, SeekOrigin.Begin);
@@ -122,7 +122,7 @@ namespace Steeltoe.Management.EndpointOwin.Metrics.Test
             var ep = new MetricsEndpoint(opts, stats);
             var middle = new MetricsEndpointOwinMiddleware(null, ep);
 
-            var context = CreateRequest("GET", "/metrics/foo.bar");
+            var context = CreateRequest("GET", "/actuator/metrics/foo.bar");
 
             await middle.HandleMetricsRequestAsync(context);
             Assert.Equal(404, context.Response.StatusCode);
@@ -141,7 +141,7 @@ namespace Steeltoe.Management.EndpointOwin.Metrics.Test
 
             var middle = new MetricsEndpointOwinMiddleware(null, ep);
 
-            var context = CreateRequest("GET", "/metrics/test.test", "?tag=a:v1");
+            var context = CreateRequest("GET", "/actuator/metrics/test.test", "?tag=a:v1");
 
             await middle.HandleMetricsRequestAsync(context);
             Assert.Equal(200, context.Response.StatusCode);
@@ -160,14 +160,14 @@ namespace Steeltoe.Management.EndpointOwin.Metrics.Test
             var ep = new MetricsEndpoint(opts, stats);
             var middle = new MetricsEndpointOwinMiddleware(null, ep);
 
-            Assert.True(middle.RequestVerbAndPathMatch("GET", "/metrics"));
-            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/metrics"));
-            Assert.False(middle.RequestVerbAndPathMatch("GET", "/badpath"));
-            Assert.False(middle.RequestVerbAndPathMatch("POST", "/metrics"));
-            Assert.False(middle.RequestVerbAndPathMatch("DELETE", "/metrics"));
-            Assert.True(middle.RequestVerbAndPathMatch("GET", "/metrics/Foo.Bar.Class"));
-            Assert.True(middle.RequestVerbAndPathMatch("GET", "/metrics/Foo.Bar.Class?tag=key:value&tag=key1:value1"));
-            Assert.True(middle.RequestVerbAndPathMatch("GET", "/metrics?tag=key:value&tag=key1:value1"));
+            Assert.True(middle.RequestVerbAndPathMatch("GET", "/actuator/metrics"));
+            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/actuator/metrics"));
+            Assert.False(middle.RequestVerbAndPathMatch("GET", "/actuator/badpath"));
+            Assert.False(middle.RequestVerbAndPathMatch("POST", "/actuator/metrics"));
+            Assert.False(middle.RequestVerbAndPathMatch("DELETE", "/actuator/metrics"));
+            Assert.True(middle.RequestVerbAndPathMatch("GET", "/actuator/metrics/Foo.Bar.Class"));
+            Assert.True(middle.RequestVerbAndPathMatch("GET", "/actuator/metrics/Foo.Bar.Class?tag=key:value&tag=key1:value1"));
+            Assert.True(middle.RequestVerbAndPathMatch("GET", "/actuator/metrics?tag=key:value&tag=key1:value1"));
         }
 
         private IOwinContext CreateRequest(string method, string path, string query = null)

--- a/test/Steeltoe.Management.EndpointOwin.Test/Refresh/RefreshEndpointOwinMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Refresh/RefreshEndpointOwinMiddlewareTest.cs
@@ -33,7 +33,7 @@ namespace Steeltoe.Management.EndpointOwin.Refresh.Test
             ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
             configurationBuilder.AddInMemoryCollection(OwinTestHelpers.Appsettings);
             var middle = new EndpointOwinMiddleware<IList<string>>(null, new RefreshEndpoint(new RefreshOptions(), configurationBuilder.Build()));
-            var context = OwinTestHelpers.CreateRequest("GET", "/refresh");
+            var context = OwinTestHelpers.CreateRequest("GET", "/actuator/refresh");
 
             // act
             var json = await middle.InvokeAndReadResponse(context);
@@ -75,9 +75,9 @@ namespace Steeltoe.Management.EndpointOwin.Refresh.Test
             var ep = new RefreshEndpoint(opts, config);
             var middle = new EndpointOwinMiddleware<IList<string>>(null, ep);
 
-            Assert.True(middle.RequestVerbAndPathMatch("GET", "/refresh"));
-            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/refresh"));
-            Assert.False(middle.RequestVerbAndPathMatch("GET", "/badpath"));
+            Assert.True(middle.RequestVerbAndPathMatch("GET", "/actuator/refresh"));
+            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/actuator/refresh"));
+            Assert.False(middle.RequestVerbAndPathMatch("GET", "/actuator/badpath"));
         }
     }
 }

--- a/test/Steeltoe.Management.EndpointOwin.Test/Security/SecurityMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Security/SecurityMiddlewareTest.cs
@@ -54,6 +54,7 @@ namespace Steeltoe.Management.Endpoint.Security.Test
         {
             Environment.SetEnvironmentVariable("management__endpoints__enabled", "true");
             Environment.SetEnvironmentVariable("management__endpoints__info__sensitive", "true");
+            Environment.SetEnvironmentVariable("VCAP_APPLICATION", "somestuff");
 
             using (var server = TestServer.Create<SecureStartup>())
             {

--- a/test/Steeltoe.Management.EndpointOwin.Test/ThreadDump/ThreadDumpEndpointOwinMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/ThreadDump/ThreadDumpEndpointOwinMiddlewareTest.cs
@@ -30,7 +30,7 @@ namespace Steeltoe.Management.EndpointOwin.ThreadDump.Test
             // arrange
             var opts = new ThreadDumpOptions();
             var middle = new EndpointOwinMiddleware<List<ThreadInfo>>(null, new ThreadDumpEndpoint(opts, new ThreadDumper(opts)));
-            var context = OwinTestHelpers.CreateRequest("GET", "/dump");
+            var context = OwinTestHelpers.CreateRequest("GET", "/actuator/dump");
 
             // act
             var json = await middle.InvokeAndReadResponse(context);
@@ -76,9 +76,9 @@ namespace Steeltoe.Management.EndpointOwin.ThreadDump.Test
             var ep = new ThreadDumpEndpoint(opts, obs);
             var middle = new EndpointOwinMiddleware<List<ThreadInfo>>(null, ep);
 
-            Assert.True(middle.RequestVerbAndPathMatch("GET", "/dump"));
-            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/dump"));
-            Assert.False(middle.RequestVerbAndPathMatch("GET", "/badpath"));
+            Assert.True(middle.RequestVerbAndPathMatch("GET", "/actuator/dump"));
+            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/actuator/dump"));
+            Assert.False(middle.RequestVerbAndPathMatch("GET", "/actuator/badpath"));
         }
     }
 }

--- a/test/Steeltoe.Management.EndpointOwin.Test/Trace/TraceEndpointOwinMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Trace/TraceEndpointOwinMiddlewareTest.cs
@@ -31,7 +31,7 @@ namespace Steeltoe.Management.EndpointOwin.Trace.Test
             var opts = new TraceOptions();
             var ep = new TestTraceEndpoint(opts, new TraceDiagnosticObserver(opts));
             var middle = new EndpointOwinMiddleware<List<TraceResult>>(null, ep);
-            var context = OwinTestHelpers.CreateRequest("GET", "/trace");
+            var context = OwinTestHelpers.CreateRequest("GET", "/actuator/trace");
 
             // act
             var json = await middle.InvokeAndReadResponse(context);
@@ -72,9 +72,9 @@ namespace Steeltoe.Management.EndpointOwin.Trace.Test
             var ep = new TraceEndpoint(opts, obs);
             var middle = new EndpointOwinMiddleware<List<TraceResult>>(null, ep);
 
-            Assert.True(middle.RequestVerbAndPathMatch("GET", "/trace"));
-            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/trace"));
-            Assert.False(middle.RequestVerbAndPathMatch("GET", "/badpath"));
+            Assert.True(middle.RequestVerbAndPathMatch("GET", "/actuator/trace"));
+            Assert.False(middle.RequestVerbAndPathMatch("PUT", "/actuator/trace"));
+            Assert.False(middle.RequestVerbAndPathMatch("GET", "/actuator/badpath"));
         }
     }
 }

--- a/test/Steeltoe.Management.EndpointWeb.Test/SensitiveEndpointTests.cs
+++ b/test/Steeltoe.Management.EndpointWeb.Test/SensitiveEndpointTests.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.Net;
 using Xunit;
 
@@ -19,6 +20,11 @@ namespace Steeltoe.Management.EndpointWeb.Test
 {
     public class SensitiveEndpointTests
     {
+        public SensitiveEndpointTests()
+        {
+            Environment.SetEnvironmentVariable("VCAP_APPLICATION", "somestuff");
+        }
+
         private Settings _defaultSettings = DefaultTestSettingsConfig.DefaultSettings;
 
         [Fact]

--- a/test/Steeltoe.Management.EndpointWeb.Test/Steeltoe.Management.EndpointWeb.Test.csproj
+++ b/test/Steeltoe.Management.EndpointWeb.Test/Steeltoe.Management.EndpointWeb.Test.csproj
@@ -12,8 +12,9 @@
 
     <StartupObject />
   </PropertyGroup>
-
-
+  
+  <Import Project="..\..\targetframework.props" />
+  
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(AspNetCoreTestVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="$(AspNetCoreTestVersion)" />


### PR DESCRIPTION
When management endpoints are used by an app hosted in Cloud Foundry, this PR allows Apps Manager integration to work while also allowing other requests to endpoints still work. Fixes #32 