### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/open_source_licenses.txt
+++ b/open_source_licenses.txt
@@ -275,7 +275,7 @@ This tool is not used in the release binaries.
 The development solution uses the BookSleeve package from nuget
 (https://code.google.com/p/booksleeve/) by Marc Gravell. This is licensed
 under the Apache 2.0 license; full details are available here:
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 This tool is not used in the release binaries.
 
 
@@ -598,7 +598,7 @@ Licensed under the Apache License, Version 2.0 (the "License"); you
 may not use this file except in compliance with the License. You may
 obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -615,7 +615,7 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 these files except in compliance with the License. You may obtain a copy of the
 License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed
 under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
@@ -631,7 +631,7 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 these files except in compliance with the License. You may obtain a copy of the
 License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed
 under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
@@ -647,7 +647,7 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 these files except in compliance with the License. You may obtain a copy of the
 License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed
 under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
@@ -663,7 +663,7 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 these files except in compliance with the License. You may obtain a copy of the
 License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed
 under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
@@ -679,7 +679,7 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 these files except in compliance with the License. You may obtain a copy of the
 License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed
 under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
@@ -695,7 +695,7 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 these files except in compliance with the License. You may obtain a copy of the
 License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed
 under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
@@ -711,7 +711,7 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 these files except in compliance with the License. You may obtain a copy of the
 License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed
 under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
@@ -727,7 +727,7 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 these files except in compliance with the License. You may obtain a copy of the
 License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed
 under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
@@ -743,7 +743,7 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 these files except in compliance with the License. You may obtain a copy of the
 License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed
 under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
@@ -759,7 +759,7 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 these files except in compliance with the License. You may obtain a copy of the
 License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed
 under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
@@ -775,7 +775,7 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 these files except in compliance with the License. You may obtain a copy of the
 License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed
 under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
@@ -791,7 +791,7 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 these files except in compliance with the License. You may obtain a copy of the
 License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed
 under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
@@ -807,7 +807,7 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 these files except in compliance with the License. You may obtain a copy of the
 License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed
 under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
@@ -823,7 +823,7 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 these files except in compliance with the License. You may obtain a copy of the
 License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed
 under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
@@ -839,7 +839,7 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 these files except in compliance with the License. You may obtain a copy of the
 License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed
 under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
@@ -855,7 +855,7 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 these files except in compliance with the License. You may obtain a copy of the
 License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed
 under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
@@ -871,7 +871,7 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 these files except in compliance with the License. You may obtain a copy of the
 License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed
 under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
@@ -887,7 +887,7 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 these files except in compliance with the License. You may obtain a copy of the
 License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed
 under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
@@ -903,7 +903,7 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 these files except in compliance with the License. You may obtain a copy of the
 License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed
 under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
@@ -919,7 +919,7 @@ specific language governing permissions and limitations under the License.
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -937,7 +937,7 @@ specific language governing permissions and limitations under the License.
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -953,7 +953,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
@@ -968,7 +968,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
@@ -985,7 +985,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -1002,7 +1002,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -1019,7 +1019,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -1036,7 +1036,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -1053,7 +1053,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -1070,7 +1070,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -1087,7 +1087,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -1104,7 +1104,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -1121,7 +1121,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -1138,7 +1138,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -1155,7 +1155,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -1172,7 +1172,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -1189,7 +1189,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -1206,7 +1206,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -1223,7 +1223,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -1240,7 +1240,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -1258,7 +1258,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 Apache License 
 
 Version 2.0, January 2004 
-http://www.apache.org/licenses/ 
+https://www.apache.org/licenses/ 
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
 
@@ -1437,19 +1437,19 @@ END OF TERMS AND CONDITIONS
 Creative Commons Attribution-ShareAlike 4.0 International 
 
 Official translations of this license are available in other languages.
-Creative Commons Corporation (“Creative Commons”) is not a law firm and does not provide legal services or legal advice. Distribution of Creative Commons public licenses does not create a lawyer-client or other relationship. Creative Commons makes its licenses and related information available on an “as-is” basis. Creative Commons gives no warranties regarding its licenses, any material licensed under their terms and conditions, or any related information. Creative Commons disclaims all liability for damages resulting from their use to the fullest extent possible.
+Creative Commons Corporation (ï¿½Creative Commonsï¿½) is not a law firm and does not provide legal services or legal advice. Distribution of Creative Commons public licenses does not create a lawyer-client or other relationship. Creative Commons makes its licenses and related information available on an ï¿½as-isï¿½ basis. Creative Commons gives no warranties regarding its licenses, any material licensed under their terms and conditions, or any related information. Creative Commons disclaims all liability for damages resulting from their use to the fullest extent possible.
 
 Using Creative Commons Public Licenses
 
 Creative Commons public licenses provide a standard set of terms and conditions that creators and other rights holders may use to share original works of authorship and other material subject to copyright and certain other rights specified in the public license below. The following considerations are for informational purposes only, are not exhaustive, and do not form part of our licenses.
 
 Considerations for licensors: Our public licenses are intended for use by those authorized to give the public permission to use material in ways otherwise restricted by copyright and certain other rights. Our licenses are irrevocable. Licensors should read and understand the terms and conditions of the license they choose before applying it. Licensors should also secure all rights necessary before applying our licenses so that the public can reuse the material as expected. Licensors should clearly mark any material not subject to the license. This includes other CC-licensed material, or material used under an exception or limitation to copyright. More considerations for licensors.
-Considerations for the public: By using one of our public licenses, a licensor grants the public permission to use the licensed material under specified terms and conditions. If the licensor’s permission is not necessary for any reason–for example, because of any applicable exception or limitation to copyright–then that use is not regulated by the license. Our licenses grant only permissions under copyright and certain other rights that a licensor has authority to grant. Use of the licensed material may still be restricted for other reasons, including because others have copyright or other rights in the material. A licensor may make special requests, such as asking that all changes be marked or described. Although not required by our licenses, you are encouraged to respect those requests where reasonable. More considerations for the public.
+Considerations for the public: By using one of our public licenses, a licensor grants the public permission to use the licensed material under specified terms and conditions. If the licensorï¿½s permission is not necessary for any reasonï¿½for example, because of any applicable exception or limitation to copyrightï¿½then that use is not regulated by the license. Our licenses grant only permissions under copyright and certain other rights that a licensor has authority to grant. Use of the licensed material may still be restricted for other reasons, including because others have copyright or other rights in the material. A licensor may make special requests, such as asking that all changes be marked or described. Although not required by our licenses, you are encouraged to respect those requests where reasonable. More considerations for the public.
 Creative Commons Attribution-ShareAlike 4.0 International Public License
 
 By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution-ShareAlike 4.0 International Public License ("Public License"). To the extent this Public License may be interpreted as a contract, You are granted the Licensed Rights in consideration of Your acceptance of these terms and conditions, and the Licensor grants You such rights in consideration of benefits the Licensor receives from making the Licensed Material available under these terms and conditions.
 
-Section 1 – Definitions.
+Section 1 ï¿½ Definitions.
 
 Adapted Material means material subject to Copyright and Similar Rights that is derived from or based upon the Licensed Material and in which the Licensed Material is translated, altered, arranged, transformed, or otherwise modified in a manner requiring permission under the Copyright and Similar Rights held by the Licensor. For purposes of this Public License, where the Licensed Material is a musical work, performance, or sound recording, Adapted Material is always produced where the Licensed Material is synched in timed relation with a moving image.
 Adapter's License means the license You apply to Your Copyright and Similar Rights in Your contributions to Adapted Material in accordance with the terms and conditions of this Public License.
@@ -1464,7 +1464,7 @@ Licensor means the individual(s) or entity(ies) granting rights under this Publi
 Share means to provide material to the public by any means or process that requires permission under the Licensed Rights, such as reproduction, public display, public performance, distribution, dissemination, communication, or importation, and to make material available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them.
 Sui Generis Database Rights means rights other than copyright resulting from Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, as amended and/or succeeded, as well as other essentially equivalent rights anywhere in the world.
 You means the individual or entity exercising the Licensed Rights under this Public License. Your has a corresponding meaning.
-Section 2 – Scope.
+Section 2 ï¿½ Scope.
 
 License grant.
 Subject to the terms and conditions of this Public License, the Licensor hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive, irrevocable license to exercise the Licensed Rights in the Licensed Material to:
@@ -1474,8 +1474,8 @@ Exceptions and Limitations. For the avoidance of doubt, where Exceptions and Lim
 Term. The term of this Public License is specified in Section 6(a).
 Media and formats; technical modifications allowed. The Licensor authorizes You to exercise the Licensed Rights in all media and formats whether now known or hereafter created, and to make technical modifications necessary to do so. The Licensor waives and/or agrees not to assert any right or authority to forbid You from making technical modifications necessary to exercise the Licensed Rights, including technical modifications necessary to circumvent Effective Technological Measures. For purposes of this Public License, simply making modifications authorized by this Section 2(a)(4) never produces Adapted Material.
 Downstream recipients.
-Offer from the Licensor – Licensed Material. Every recipient of the Licensed Material automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.
-Additional offer from the Licensor – Adapted Material. Every recipient of Adapted Material from You automatically receives an offer from the Licensor to exercise the Licensed Rights in the Adapted Material under the conditions of the Adapter’s License You apply.
+Offer from the Licensor ï¿½ Licensed Material. Every recipient of the Licensed Material automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.
+Additional offer from the Licensor ï¿½ Adapted Material. Every recipient of Adapted Material from You automatically receives an offer from the Licensor to exercise the Licensed Rights in the Adapted Material under the conditions of the Adapterï¿½s License You apply.
 No downstream restrictions. You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, the Licensed Material if doing so restricts exercise of the Licensed Rights by any recipient of the Licensed Material.
 No endorsement. Nothing in this Public License constitutes or may be construed as permission to assert or imply that You are, or that Your use of the Licensed Material is, connected with, or sponsored, endorsed, or granted official status by, the Licensor or others designated to receive attribution as provided in Section 3(a)(1)(A)(i).
 Other rights.
@@ -1483,7 +1483,7 @@ Other rights.
 Moral rights, such as the right of integrity, are not licensed under this Public License, nor are publicity, privacy, and/or other similar personality rights; however, to the extent possible, the Licensor waives and/or agrees not to assert any such rights held by the Licensor to the limited extent necessary to allow You to exercise the Licensed Rights, but not otherwise.
 Patent and trademark rights are not licensed under this Public License.
 To the extent possible, the Licensor waives any right to collect royalties from You for the exercise of the Licensed Rights, whether directly or through a collecting society under any voluntary or waivable statutory or compulsory licensing scheme. In all other cases the Licensor expressly reserves any right to collect such royalties.
-Section 3 – License Conditions.
+Section 3 ï¿½ License Conditions.
 
 Your exercise of the Licensed Rights is expressly made subject to the following conditions.
 
@@ -1504,10 +1504,10 @@ If requested by the Licensor, You must remove any of the information required by
 ShareAlike.
 In addition to the conditions in Section 3(a), if You Share Adapted Material You produce, the following conditions also apply.
 
-The Adapter’s License You apply must be a Creative Commons license with the same License Elements, this version or later, or a BY-SA Compatible License.
+The Adapterï¿½s License You apply must be a Creative Commons license with the same License Elements, this version or later, or a BY-SA Compatible License.
 You must include the text of, or the URI or hyperlink to, the Adapter's License You apply. You may satisfy this condition in any reasonable manner based on the medium, means, and context in which You Share Adapted Material.
 You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, Adapted Material that restrict exercise of the rights granted under the Adapter's License You apply.
-Section 4 – Sui Generis Database Rights.
+Section 4 ï¿½ Sui Generis Database Rights.
 
 Where the Licensed Rights include Sui Generis Database Rights that apply to Your use of the Licensed Material:
 
@@ -1515,12 +1515,12 @@ for the avoidance of doubt, Section 2(a)(1) grants You the right to extract, reu
 if You include all or a substantial portion of the database contents in a database in which You have Sui Generis Database Rights, then the database in which You have Sui Generis Database Rights (but not its individual contents) is Adapted Material, including for purposes of Section 3(b); and
 You must comply with the conditions in Section 3(a) if You Share all or a substantial portion of the contents of the database.
 For the avoidance of doubt, this Section 4 supplements and does not replace Your obligations under this Public License where the Licensed Rights include other Copyright and Similar Rights.
-Section 5 – Disclaimer of Warranties and Limitation of Liability.
+Section 5 ï¿½ Disclaimer of Warranties and Limitation of Liability.
 
 Unless otherwise separately undertaken by the Licensor, to the extent possible, the Licensor offers the Licensed Material as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Material, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You.
 To the extent possible, in no event will the Licensor be liable to You on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damages arising out of this Public License or use of the Licensed Material, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this limitation may not apply to You.
 The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.
-Section 6 – Term and Termination.
+Section 6 ï¿½ Term and Termination.
 
 This Public License applies for the term of the Copyright and Similar Rights licensed here. However, if You fail to comply with this Public License, then Your rights under this Public License terminate automatically.
 Where Your right to use the Licensed Material has terminated under Section 6(a), it reinstates:
@@ -1530,17 +1530,17 @@ upon express reinstatement by the Licensor.
 For the avoidance of doubt, this Section 6(b) does not affect any right the Licensor may have to seek remedies for Your violations of this Public License.
 For the avoidance of doubt, the Licensor may also offer the Licensed Material under separate terms or conditions or stop distributing the Licensed Material at any time; however, doing so will not terminate this Public License.
 Sections 1, 5, 6, 7, and 8 survive termination of this Public License.
-Section 7 – Other Terms and Conditions.
+Section 7 ï¿½ Other Terms and Conditions.
 
 The Licensor shall not be bound by any additional or different terms or conditions communicated by You unless expressly agreed.
 Any arrangements, understandings, or agreements regarding the Licensed Material not stated herein are separate from and independent of the terms and conditions of this Public License.
-Section 8 – Interpretation.
+Section 8 ï¿½ Interpretation.
 
 For the avoidance of doubt, this Public License does not, and shall not be interpreted to, reduce, limit, restrict, or impose conditions on any use of the Licensed Material that could lawfully be made without permission under this Public License.
 To the extent possible, if any provision of this Public License is deemed unenforceable, it shall be automatically reformed to the minimum extent necessary to make it enforceable. If the provision cannot be reformed, it shall be severed from this Public License without affecting the enforceability of the remaining terms and conditions.
 No term or condition of this Public License will be waived and no failure to comply consented to unless expressly agreed to by the Licensor.
 Nothing in this Public License constitutes or may be interpreted as a limitation upon, or waiver of, any privileges and immunities that apply to the Licensor or You, including from the legal processes of any jurisdiction or authority.
-Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to apply one of its public licenses to material it publishes and in those instances will be considered the “Licensor.” The text of the Creative Commons public licenses is dedicated to the public domain under the CC0 Public Domain Dedication. Except for the limited purpose of indicating that material is shared under a Creative Commons public license or as otherwise permitted by the Creative Commons policies published at creativecommons.org/policies, Creative Commons does not authorize the use of the trademark “Creative Commons” or any other trademark or logo of Creative Commons without its prior written consent including, without limitation, in connection with any unauthorized modifications to any of its public licenses or any other arrangements, understandings, or agreements concerning use of licensed material. For the avoidance of doubt, this paragraph does not form part of the public licenses.
+Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to apply one of its public licenses to material it publishes and in those instances will be considered the ï¿½Licensor.ï¿½ The text of the Creative Commons public licenses is dedicated to the public domain under the CC0 Public Domain Dedication. Except for the limited purpose of indicating that material is shared under a Creative Commons public license or as otherwise permitted by the Creative Commons policies published at creativecommons.org/policies, Creative Commons does not authorize the use of the trademark ï¿½Creative Commonsï¿½ or any other trademark or logo of Creative Commons without its prior written consent including, without limitation, in connection with any unauthorized modifications to any of its public licenses or any other arrangements, understandings, or agreements concerning use of licensed material. For the avoidance of doubt, this paragraph does not form part of the public licenses.
 
 Creative Commons may be contacted at creativecommons.org.
 

--- a/src/Steeltoe.Management.CloudFoundryCore/CloudFoundryApplicationBuilderExtensions.cs
+++ b/src/Steeltoe.Management.CloudFoundryCore/CloudFoundryApplicationBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.CloudFoundryCore/CloudFoundryServiceCollectionExtensions.cs
+++ b/src/Steeltoe.Management.CloudFoundryCore/CloudFoundryServiceCollectionExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.Diagnostics/MiniDumper.cs
+++ b/src/Steeltoe.Management.Diagnostics/MiniDumper.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.Diagnostics/Properties/AssemblyInfo.cs
+++ b/src/Steeltoe.Management.Diagnostics/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/AbstractEndpoint.cs
+++ b/src/Steeltoe.Management.EndpointBase/AbstractEndpoint.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/AbstractEndpointOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/AbstractEndpointOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/AbstractOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/AbstractOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/CloudFoundry/CloudFoundryEndpoint.cs
+++ b/src/Steeltoe.Management.EndpointBase/CloudFoundry/CloudFoundryEndpoint.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/CloudFoundry/CloudFoundryEndpointOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/CloudFoundry/CloudFoundryEndpointOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/CloudFoundry/CloudFoundryManagementOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/CloudFoundry/CloudFoundryManagementOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/CloudFoundry/CloudFoundryOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/CloudFoundry/CloudFoundryOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/CloudFoundry/ICloudFoundryOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/CloudFoundry/ICloudFoundryOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/CloudFoundry/Link.cs
+++ b/src/Steeltoe.Management.EndpointBase/CloudFoundry/Link.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/CloudFoundry/Links.cs
+++ b/src/Steeltoe.Management.EndpointBase/CloudFoundry/Links.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/CloudFoundry/SecurityBase.cs
+++ b/src/Steeltoe.Management.EndpointBase/CloudFoundry/SecurityBase.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/CloudFoundry/SecurityResult.cs
+++ b/src/Steeltoe.Management.EndpointBase/CloudFoundry/SecurityResult.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Diagnostics/DiagnosticServices.cs
+++ b/src/Steeltoe.Management.EndpointBase/Diagnostics/DiagnosticServices.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Discovery/ActuatorDiscoveryEndpoint.cs
+++ b/src/Steeltoe.Management.EndpointBase/Discovery/ActuatorDiscoveryEndpoint.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Discovery/ActuatorDiscoveryEndpointOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Discovery/ActuatorDiscoveryEndpointOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Discovery/ActuatorManagementOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Discovery/ActuatorManagementOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Discovery/DiscoveryService.cs
+++ b/src/Steeltoe.Management.EndpointBase/Discovery/DiscoveryService.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Discovery/IActuatorDiscoveryOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Discovery/IActuatorDiscoveryOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/EndpointExtensions.cs
+++ b/src/Steeltoe.Management.EndpointBase/EndpointExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Env/EnvEndpoint.cs
+++ b/src/Steeltoe.Management.EndpointBase/Env/EnvEndpoint.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Env/EnvEndpointOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Env/EnvEndpointOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Env/EnvOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Env/EnvOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Env/EnvironmentDescriptor.cs
+++ b/src/Steeltoe.Management.EndpointBase/Env/EnvironmentDescriptor.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Env/GenericHostingEnvironment.cs
+++ b/src/Steeltoe.Management.EndpointBase/Env/GenericHostingEnvironment.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Env/IEnvOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Env/IEnvOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Env/PropertySourceDescriptor.cs
+++ b/src/Steeltoe.Management.EndpointBase/Env/PropertySourceDescriptor.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Env/PropertyValueDescriptor.cs
+++ b/src/Steeltoe.Management.EndpointBase/Env/PropertyValueDescriptor.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Env/Sanitizer.cs
+++ b/src/Steeltoe.Management.EndpointBase/Env/Sanitizer.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Exposure.cs
+++ b/src/Steeltoe.Management.EndpointBase/Exposure.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Health/Contributor/DiskSpaceContributor.cs
+++ b/src/Steeltoe.Management.EndpointBase/Health/Contributor/DiskSpaceContributor.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Health/Contributor/DiskSpaceContributorOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Health/Contributor/DiskSpaceContributorOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Health/DefaultHealthAggregator.cs
+++ b/src/Steeltoe.Management.EndpointBase/Health/DefaultHealthAggregator.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Health/HealthEndpoint.cs
+++ b/src/Steeltoe.Management.EndpointBase/Health/HealthEndpoint.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Health/HealthEndpointOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Health/HealthEndpointOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Health/HealthJsonConverter.cs
+++ b/src/Steeltoe.Management.EndpointBase/Health/HealthJsonConverter.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Health/HealthOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Health/HealthOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Health/HealthRegistrationsAggregator.cs
+++ b/src/Steeltoe.Management.EndpointBase/Health/HealthRegistrationsAggregator.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Health/IHealthAggregator.cs
+++ b/src/Steeltoe.Management.EndpointBase/Health/IHealthAggregator.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Health/IHealthOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Health/IHealthOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Health/IHealthRegistrationsAggregator.cs
+++ b/src/Steeltoe.Management.EndpointBase/Health/IHealthRegistrationsAggregator.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Health/Registration/HealthCheckExtensions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Health/Registration/HealthCheckExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Health/ShowDetails.cs
+++ b/src/Steeltoe.Management.EndpointBase/Health/ShowDetails.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/HeapDump/HeapDumpEndpoint.cs
+++ b/src/Steeltoe.Management.EndpointBase/HeapDump/HeapDumpEndpoint.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/HeapDump/HeapDumpEndpointOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/HeapDump/HeapDumpEndpointOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/HeapDump/HeapDumpOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/HeapDump/HeapDumpOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/HeapDump/HeapDumper.cs
+++ b/src/Steeltoe.Management.EndpointBase/HeapDump/HeapDumper.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/HeapDump/IHeapDumpOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/HeapDump/IHeapDumpOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/HeapDump/IHeapDumper.cs
+++ b/src/Steeltoe.Management.EndpointBase/HeapDump/IHeapDumper.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/IEndpoint.cs
+++ b/src/Steeltoe.Management.EndpointBase/IEndpoint.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/IEndpointOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/IEndpointOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/IManagementOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/IManagementOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Info/Contributor/AbstractConfigurationContributor.cs
+++ b/src/Steeltoe.Management.EndpointBase/Info/Contributor/AbstractConfigurationContributor.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Info/Contributor/AppSettingsInfoContributor.cs
+++ b/src/Steeltoe.Management.EndpointBase/Info/Contributor/AppSettingsInfoContributor.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Info/Contributor/GitInfoContributor.cs
+++ b/src/Steeltoe.Management.EndpointBase/Info/Contributor/GitInfoContributor.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Info/IInfoBuilder.cs
+++ b/src/Steeltoe.Management.EndpointBase/Info/IInfoBuilder.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Info/IInfoContributor.cs
+++ b/src/Steeltoe.Management.EndpointBase/Info/IInfoContributor.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Info/IInfoOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Info/IInfoOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Info/InfoBuilder.cs
+++ b/src/Steeltoe.Management.EndpointBase/Info/InfoBuilder.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Info/InfoEndpoint.cs
+++ b/src/Steeltoe.Management.EndpointBase/Info/InfoEndpoint.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Info/InfoEndpointOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Info/InfoEndpointOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Info/InfoOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Info/InfoOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Loggers/ILoggersOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Loggers/ILoggersOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Loggers/LoggerLevels.cs
+++ b/src/Steeltoe.Management.EndpointBase/Loggers/LoggerLevels.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Loggers/LoggersChangeRequest.cs
+++ b/src/Steeltoe.Management.EndpointBase/Loggers/LoggersChangeRequest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Loggers/LoggersEndpoint.cs
+++ b/src/Steeltoe.Management.EndpointBase/Loggers/LoggersEndpoint.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Loggers/LoggersEndpointOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Loggers/LoggersEndpointOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Loggers/LoggersOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Loggers/LoggersOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/ManagementEndpointOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/ManagementEndpointOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/ManagementOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/ManagementOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Mappings/ApplicationMappings.cs
+++ b/src/Steeltoe.Management.EndpointBase/Mappings/ApplicationMappings.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Mappings/ContextMappings.cs
+++ b/src/Steeltoe.Management.EndpointBase/Mappings/ContextMappings.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Mappings/IMappingsOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Mappings/IMappingsOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Mappings/IRouteDetails.cs
+++ b/src/Steeltoe.Management.EndpointBase/Mappings/IRouteDetails.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Mappings/MappingDescription.cs
+++ b/src/Steeltoe.Management.EndpointBase/Mappings/MappingDescription.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Mappings/MappingsEndpoint.cs
+++ b/src/Steeltoe.Management.EndpointBase/Mappings/MappingsEndpoint.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Mappings/MappingsEndpointOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Mappings/MappingsEndpointOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Mappings/MappingsOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Mappings/MappingsOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Metrics/IMetricsOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Metrics/IMetricsOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Metrics/IMetricsResponse.cs
+++ b/src/Steeltoe.Management.EndpointBase/Metrics/IMetricsResponse.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Metrics/MetricSample.cs
+++ b/src/Steeltoe.Management.EndpointBase/Metrics/MetricSample.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Metrics/MetricStatistic.cs
+++ b/src/Steeltoe.Management.EndpointBase/Metrics/MetricStatistic.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Metrics/MetricTag.cs
+++ b/src/Steeltoe.Management.EndpointBase/Metrics/MetricTag.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Metrics/MetricsEndpoint.cs
+++ b/src/Steeltoe.Management.EndpointBase/Metrics/MetricsEndpoint.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Metrics/MetricsEndpointOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Metrics/MetricsEndpointOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Metrics/MetricsListNamesResponse.cs
+++ b/src/Steeltoe.Management.EndpointBase/Metrics/MetricsListNamesResponse.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Metrics/MetricsOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Metrics/MetricsOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Metrics/MetricsRequest.cs
+++ b/src/Steeltoe.Management.EndpointBase/Metrics/MetricsRequest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Metrics/MetricsResponse.cs
+++ b/src/Steeltoe.Management.EndpointBase/Metrics/MetricsResponse.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Metrics/Observer/CLRRuntimeObserver.cs
+++ b/src/Steeltoe.Management.EndpointBase/Metrics/Observer/CLRRuntimeObserver.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Metrics/Observer/CLRRuntimeSource.cs
+++ b/src/Steeltoe.Management.EndpointBase/Metrics/Observer/CLRRuntimeSource.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Metrics/Observer/HttpClientCoreObserver.cs
+++ b/src/Steeltoe.Management.EndpointBase/Metrics/Observer/HttpClientCoreObserver.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Metrics/Observer/HttpClientDesktopObserver.cs
+++ b/src/Steeltoe.Management.EndpointBase/Metrics/Observer/HttpClientDesktopObserver.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Metrics/Observer/MetricsObserver.cs
+++ b/src/Steeltoe.Management.EndpointBase/Metrics/Observer/MetricsObserver.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Metrics/OpenCensusStats.cs
+++ b/src/Steeltoe.Management.EndpointBase/Metrics/OpenCensusStats.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Metrics/OpenCensusTags.cs
+++ b/src/Steeltoe.Management.EndpointBase/Metrics/OpenCensusTags.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Middleware/EndpointMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointBase/Middleware/EndpointMiddleware.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Properties/AssemblyInfo.cs
+++ b/src/Steeltoe.Management.EndpointBase/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Refresh/IRefreshOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Refresh/IRefreshOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Refresh/RefreshEndpoint.cs
+++ b/src/Steeltoe.Management.EndpointBase/Refresh/RefreshEndpoint.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Refresh/RefreshEndpointOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Refresh/RefreshEndpointOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Refresh/RefreshOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Refresh/RefreshOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Security/EndpointClaim.cs
+++ b/src/Steeltoe.Management.EndpointBase/Security/EndpointClaim.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Security/Permissions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Security/Permissions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/ThreadDump/IThreadDumpOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/ThreadDump/IThreadDumpOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/ThreadDump/IThreadDumper.cs
+++ b/src/Steeltoe.Management.EndpointBase/ThreadDump/IThreadDumper.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/ThreadDump/LockInfo.cs
+++ b/src/Steeltoe.Management.EndpointBase/ThreadDump/LockInfo.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/ThreadDump/MetaDataImportProvider.cs
+++ b/src/Steeltoe.Management.EndpointBase/ThreadDump/MetaDataImportProvider.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/ThreadDump/MonitorInfo.cs
+++ b/src/Steeltoe.Management.EndpointBase/ThreadDump/MonitorInfo.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/ThreadDump/StackTraceElement.cs
+++ b/src/Steeltoe.Management.EndpointBase/ThreadDump/StackTraceElement.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/ThreadDump/TState.cs
+++ b/src/Steeltoe.Management.EndpointBase/ThreadDump/TState.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/ThreadDump/ThreadDumpEndpoint.cs
+++ b/src/Steeltoe.Management.EndpointBase/ThreadDump/ThreadDumpEndpoint.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/ThreadDump/ThreadDumpEndpointOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/ThreadDump/ThreadDumpEndpointOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/ThreadDump/ThreadDumpOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/ThreadDump/ThreadDumpOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/ThreadDump/ThreadDumper.cs
+++ b/src/Steeltoe.Management.EndpointBase/ThreadDump/ThreadDumper.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/ThreadDump/ThreadInfo.cs
+++ b/src/Steeltoe.Management.EndpointBase/ThreadDump/ThreadInfo.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Trace/HttpTraceEndpoint.cs
+++ b/src/Steeltoe.Management.EndpointBase/Trace/HttpTraceEndpoint.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Trace/HttpTraceEndpointOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Trace/HttpTraceEndpointOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Trace/HttpTraceResult.cs
+++ b/src/Steeltoe.Management.EndpointBase/Trace/HttpTraceResult.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Trace/IHttpTraceRepository.cs
+++ b/src/Steeltoe.Management.EndpointBase/Trace/IHttpTraceRepository.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Trace/ITraceOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Trace/ITraceOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Trace/ITraceRepository.cs
+++ b/src/Steeltoe.Management.EndpointBase/Trace/ITraceRepository.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Trace/TraceEndpoint.cs
+++ b/src/Steeltoe.Management.EndpointBase/Trace/TraceEndpoint.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Trace/TraceEndpointOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Trace/TraceEndpointOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Trace/TraceOptions.cs
+++ b/src/Steeltoe.Management.EndpointBase/Trace/TraceOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Trace/TraceResult.cs
+++ b/src/Steeltoe.Management.EndpointBase/Trace/TraceResult.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointBase/Utils.cs
+++ b/src/Steeltoe.Management.EndpointBase/Utils.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/CloudFoundry/CloudFoundryEndpointMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointCore/CloudFoundry/CloudFoundryEndpointMiddleware.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/CloudFoundry/CloudFoundrySecurityMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointCore/CloudFoundry/CloudFoundrySecurityMiddleware.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/CloudFoundry/EndpointApplicationBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointCore/CloudFoundry/EndpointApplicationBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/CloudFoundry/EndpointServiceCollectionExtensions.cs
+++ b/src/Steeltoe.Management.EndpointCore/CloudFoundry/EndpointServiceCollectionExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/CoreSecurityContext.cs
+++ b/src/Steeltoe.Management.EndpointCore/CoreSecurityContext.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Discovery/ActuatorDiscoveryEndpointMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointCore/Discovery/ActuatorDiscoveryEndpointMiddleware.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Discovery/EndpointApplicationBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointCore/Discovery/EndpointApplicationBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Discovery/EndpointServiceCollectionExtensions.cs
+++ b/src/Steeltoe.Management.EndpointCore/Discovery/EndpointServiceCollectionExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Env/EndpointApplicationBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointCore/Env/EndpointApplicationBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Env/EndpointServiceCollectionExtensions.cs
+++ b/src/Steeltoe.Management.EndpointCore/Env/EndpointServiceCollectionExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Env/EnvEndpointMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointCore/Env/EnvEndpointMiddleware.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Health/EndpointApplicationBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointCore/Health/EndpointApplicationBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Health/EndpointServiceCollectionExtensions.cs
+++ b/src/Steeltoe.Management.EndpointCore/Health/EndpointServiceCollectionExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Health/HealthChecksBuilder.cs
+++ b/src/Steeltoe.Management.EndpointCore/Health/HealthChecksBuilder.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Health/HealthEndpointMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointCore/Health/HealthEndpointMiddleware.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/HeapDump/EndpointApplicationBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointCore/HeapDump/EndpointApplicationBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/HeapDump/EndpointServiceCollectionExtensions.cs
+++ b/src/Steeltoe.Management.EndpointCore/HeapDump/EndpointServiceCollectionExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/HeapDump/HeapDumpEndpointMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointCore/HeapDump/HeapDumpEndpointMiddleware.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Info/EndpointApplicationBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointCore/Info/EndpointApplicationBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Info/EndpointServiceCollectionExtensions.cs
+++ b/src/Steeltoe.Management.EndpointCore/Info/EndpointServiceCollectionExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Info/InfoEndpointMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointCore/Info/InfoEndpointMiddleware.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Loggers/EndpointApplicationBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointCore/Loggers/EndpointApplicationBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Loggers/EndpointServiceCollectionExtensions.cs
+++ b/src/Steeltoe.Management.EndpointCore/Loggers/EndpointServiceCollectionExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Loggers/LoggersEndpointMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointCore/Loggers/LoggersEndpointMiddleware.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Mappings/AspNetCoreRouteDetails.cs
+++ b/src/Steeltoe.Management.EndpointCore/Mappings/AspNetCoreRouteDetails.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Mappings/EndpointApplicationBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointCore/Mappings/EndpointApplicationBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Mappings/EndpointServiceCollectionExtensions.cs
+++ b/src/Steeltoe.Management.EndpointCore/Mappings/EndpointServiceCollectionExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Mappings/IRouteMappings.cs
+++ b/src/Steeltoe.Management.EndpointCore/Mappings/IRouteMappings.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Mappings/MappingsEndpointMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointCore/Mappings/MappingsEndpointMiddleware.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Mappings/RouteBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointCore/Mappings/RouteBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Mappings/RouteMappings.cs
+++ b/src/Steeltoe.Management.EndpointCore/Mappings/RouteMappings.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Metrics/EndpointApplicationBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointCore/Metrics/EndpointApplicationBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Metrics/EndpointServiceCollectionExtensions.cs
+++ b/src/Steeltoe.Management.EndpointCore/Metrics/EndpointServiceCollectionExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Metrics/MetricsEndpointMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointCore/Metrics/MetricsEndpointMiddleware.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Metrics/Observer/AspNetCoreHostingObserver.cs
+++ b/src/Steeltoe.Management.EndpointCore/Metrics/Observer/AspNetCoreHostingObserver.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Properties/AssemblyInfo.cs
+++ b/src/Steeltoe.Management.EndpointCore/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Refresh/EndpointApplicationBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointCore/Refresh/EndpointApplicationBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Refresh/EndpointServiceCollectionExtensions.cs
+++ b/src/Steeltoe.Management.EndpointCore/Refresh/EndpointServiceCollectionExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Refresh/RefreshEndpointMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointCore/Refresh/RefreshEndpointMiddleware.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/ThreadDump/EndpointApplicationBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointCore/ThreadDump/EndpointApplicationBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/ThreadDump/EndpointServiceCollectionExtensions.cs
+++ b/src/Steeltoe.Management.EndpointCore/ThreadDump/EndpointServiceCollectionExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/ThreadDump/ThreadDumpEndpointMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointCore/ThreadDump/ThreadDumpEndpointMiddleware.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Trace/EndpointApplicationBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointCore/Trace/EndpointApplicationBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Trace/EndpointServiceCollectionExtensions.cs
+++ b/src/Steeltoe.Management.EndpointCore/Trace/EndpointServiceCollectionExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Trace/HttpTraceDiagnosticObserver.cs
+++ b/src/Steeltoe.Management.EndpointCore/Trace/HttpTraceDiagnosticObserver.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Trace/HttpTraceEndpointMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointCore/Trace/HttpTraceEndpointMiddleware.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Trace/TraceDiagnosticObserver.cs
+++ b/src/Steeltoe.Management.EndpointCore/Trace/TraceDiagnosticObserver.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointCore/Trace/TraceEndpointMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointCore/Trace/TraceEndpointMiddleware.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/CloudFoundry/CloudFoundryEndpointAppBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointOwin/CloudFoundry/CloudFoundryEndpointAppBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/CloudFoundry/CloudFoundryEndpointOwinMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointOwin/CloudFoundry/CloudFoundryEndpointOwinMiddleware.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/CloudFoundry/CloudFoundrySecurityAppBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointOwin/CloudFoundry/CloudFoundrySecurityAppBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/CloudFoundry/CloudFoundrySecurityOwinMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointOwin/CloudFoundry/CloudFoundrySecurityOwinMiddleware.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/CloudFoundryAppBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointOwin/CloudFoundryAppBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/Diagnostics/DiagnosticSourceAppBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointOwin/Diagnostics/DiagnosticSourceAppBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/Diagnostics/DiagnosticSourceOwinMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointOwin/Diagnostics/DiagnosticSourceOwinMiddleware.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/Discovery/ActuatorDiscoveryEndpointOwinMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointOwin/Discovery/ActuatorDiscoveryEndpointOwinMiddleware.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/Discovery/DiscoveryActuatorEndpointAppBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointOwin/Discovery/DiscoveryActuatorEndpointAppBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/EndpointOwinMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointOwin/EndpointOwinMiddleware.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/Env/EnvEndpointAppBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointOwin/Env/EnvEndpointAppBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/Health/HealthEndpointAppBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointOwin/Health/HealthEndpointAppBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/Health/HealthEndpointOwinMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointOwin/Health/HealthEndpointOwinMiddleware.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/HeapDump/HeapDumpEndpointAppBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointOwin/HeapDump/HeapDumpEndpointAppBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/HeapDump/HeapDumpEndpointOwinMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointOwin/HeapDump/HeapDumpEndpointOwinMiddleware.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/Info/InfoEndpointAppBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointOwin/Info/InfoEndpointAppBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/Loggers/LoggersEndpointAppBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointOwin/Loggers/LoggersEndpointAppBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/Loggers/LoggersEndpointOwinMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointOwin/Loggers/LoggersEndpointOwinMiddleware.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/ManagementOptions.cs
+++ b/src/Steeltoe.Management.EndpointOwin/ManagementOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/Mappings/AspNetRouteDetails.cs
+++ b/src/Steeltoe.Management.EndpointOwin/Mappings/AspNetRouteDetails.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/Mappings/MappingsEndpointAppBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointOwin/Mappings/MappingsEndpointAppBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/Mappings/MappingsEndpointOwinMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointOwin/Mappings/MappingsEndpointOwinMiddleware.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/Metrics/MetricsEndpointAppBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointOwin/Metrics/MetricsEndpointAppBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/Metrics/MetricsEndpointOwinMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointOwin/Metrics/MetricsEndpointOwinMiddleware.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/Metrics/Observer/OwinHostingObserver.cs
+++ b/src/Steeltoe.Management.EndpointOwin/Metrics/Observer/OwinHostingObserver.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/Properties/AssemblyInfo.cs
+++ b/src/Steeltoe.Management.EndpointOwin/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/Refresh/RefreshEndpointAppBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointOwin/Refresh/RefreshEndpointAppBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/ThreadDump/ThreadDumpEndpointAppBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointOwin/ThreadDump/ThreadDumpEndpointAppBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/Trace/HttpTraceDiagnosticObserver.cs
+++ b/src/Steeltoe.Management.EndpointOwin/Trace/HttpTraceDiagnosticObserver.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/Trace/TraceDiagnosticObserver.cs
+++ b/src/Steeltoe.Management.EndpointOwin/Trace/TraceDiagnosticObserver.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/Trace/TraceEndpointAppBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointOwin/Trace/TraceEndpointAppBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwin/Trace/TraceEndpointOwinMiddleware.cs
+++ b/src/Steeltoe.Management.EndpointOwin/Trace/TraceEndpointOwinMiddleware.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwinAutofac/Actuators/ActuatorContainerBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointOwinAutofac/Actuators/ActuatorContainerBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwinAutofac/Actuators/CloudFoundryContainerBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointOwinAutofac/Actuators/CloudFoundryContainerBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwinAutofac/Actuators/DiagnosticSourceContainerBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointOwinAutofac/Actuators/DiagnosticSourceContainerBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwinAutofac/Actuators/EnvContainerBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointOwinAutofac/Actuators/EnvContainerBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwinAutofac/Actuators/HealthContainerBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointOwinAutofac/Actuators/HealthContainerBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwinAutofac/Actuators/HeapDumpContainerBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointOwinAutofac/Actuators/HeapDumpContainerBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwinAutofac/Actuators/InfoContainerBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointOwinAutofac/Actuators/InfoContainerBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwinAutofac/Actuators/LoggersContainerBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointOwinAutofac/Actuators/LoggersContainerBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwinAutofac/Actuators/MappingsContainerBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointOwinAutofac/Actuators/MappingsContainerBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwinAutofac/Actuators/MetricsContainerBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointOwinAutofac/Actuators/MetricsContainerBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwinAutofac/Actuators/RefreshContainerBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointOwinAutofac/Actuators/RefreshContainerBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwinAutofac/Actuators/ThreadDumpContainerBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointOwinAutofac/Actuators/ThreadDumpContainerBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwinAutofac/Actuators/TraceContainerBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointOwinAutofac/Actuators/TraceContainerBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointOwinAutofac/ContainerBuilderExtensions.cs
+++ b/src/Steeltoe.Management.EndpointOwinAutofac/ContainerBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointWeb/ActuatorConfigurator.cs
+++ b/src/Steeltoe.Management.EndpointWeb/ActuatorConfigurator.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointWeb/AspNetRouteDetails.cs
+++ b/src/Steeltoe.Management.EndpointWeb/AspNetRouteDetails.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointWeb/Handler/ActuatorDiscoveryHandler.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Handler/ActuatorDiscoveryHandler.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointWeb/Handler/ActuatorHandler.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Handler/ActuatorHandler.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointWeb/Handler/CloudFoundryCorsHandler.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Handler/CloudFoundryCorsHandler.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointWeb/Handler/CloudFoundryHandler.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Handler/CloudFoundryHandler.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointWeb/Handler/EnvHandler.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Handler/EnvHandler.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointWeb/Handler/HealthHandler.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Handler/HealthHandler.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointWeb/Handler/HeapDumpHandler.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Handler/HeapDumpHandler.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointWeb/Handler/HttpTraceHandler.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Handler/HttpTraceHandler.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointWeb/Handler/IActuatorHandler.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Handler/IActuatorHandler.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointWeb/Handler/InfoHandler.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Handler/InfoHandler.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointWeb/Handler/LoggersHandler.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Handler/LoggersHandler.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointWeb/Handler/MappingsHandler.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Handler/MappingsHandler.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointWeb/Handler/MetricsHandler.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Handler/MetricsHandler.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointWeb/Handler/RefreshHandler.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Handler/RefreshHandler.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointWeb/Handler/ThreadDumpHandler.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Handler/ThreadDumpHandler.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointWeb/Handler/TraceHandler.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Handler/TraceHandler.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointWeb/Module/ActuatorModule.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Module/ActuatorModule.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointWeb/Observer/AspNetHostingObserver.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Observer/AspNetHostingObserver.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointWeb/Observer/HttpTraceDiagnosticObserver.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Observer/HttpTraceDiagnosticObserver.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointWeb/Observer/TraceDiagnosticObserver.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Observer/TraceDiagnosticObserver.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointWeb/Security/CloudFoundrySecurity.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Security/CloudFoundrySecurity.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointWeb/Security/ISecurityService.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Security/ISecurityService.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointWeb/Security/SecurityHelper.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Security/SecurityHelper.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointWeb/Security/SecurityServiceExtension.cs
+++ b/src/Steeltoe.Management.EndpointWeb/Security/SecurityServiceExtension.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.EndpointWeb/StringExtensions.cs
+++ b/src/Steeltoe.Management.EndpointWeb/StringExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.ExporterBase/Metrics/CloudFoundryForwarder/Application.cs
+++ b/src/Steeltoe.Management.ExporterBase/Metrics/CloudFoundryForwarder/Application.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.ExporterBase/Metrics/CloudFoundryForwarder/CloudFoundryForwarderExporter.cs
+++ b/src/Steeltoe.Management.ExporterBase/Metrics/CloudFoundryForwarder/CloudFoundryForwarderExporter.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.ExporterBase/Metrics/CloudFoundryForwarder/CloudFoundryForwarderOptions.cs
+++ b/src/Steeltoe.Management.ExporterBase/Metrics/CloudFoundryForwarder/CloudFoundryForwarderOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.ExporterBase/Metrics/CloudFoundryForwarder/CloudFoundryMetricWriter.cs
+++ b/src/Steeltoe.Management.ExporterBase/Metrics/CloudFoundryForwarder/CloudFoundryMetricWriter.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.ExporterBase/Metrics/CloudFoundryForwarder/ICloudFoundryMetricWriter.cs
+++ b/src/Steeltoe.Management.ExporterBase/Metrics/CloudFoundryForwarder/ICloudFoundryMetricWriter.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.ExporterBase/Metrics/CloudFoundryForwarder/Instance.cs
+++ b/src/Steeltoe.Management.ExporterBase/Metrics/CloudFoundryForwarder/Instance.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.ExporterBase/Metrics/CloudFoundryForwarder/Message.cs
+++ b/src/Steeltoe.Management.ExporterBase/Metrics/CloudFoundryForwarder/Message.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.ExporterBase/Metrics/CloudFoundryForwarder/Metric.cs
+++ b/src/Steeltoe.Management.ExporterBase/Metrics/CloudFoundryForwarder/Metric.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.ExporterBase/Metrics/CloudFoundryForwarder/MetricType.cs
+++ b/src/Steeltoe.Management.ExporterBase/Metrics/CloudFoundryForwarder/MetricType.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.ExporterBase/Metrics/CloudFoundryForwarder/MicrometerMetricWriter.cs
+++ b/src/Steeltoe.Management.ExporterBase/Metrics/CloudFoundryForwarder/MicrometerMetricWriter.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.ExporterBase/Metrics/CloudFoundryForwarder/SpringBootMetricWriter.cs
+++ b/src/Steeltoe.Management.ExporterBase/Metrics/CloudFoundryForwarder/SpringBootMetricWriter.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.ExporterBase/Metrics/IMetricsExporter.cs
+++ b/src/Steeltoe.Management.ExporterBase/Metrics/IMetricsExporter.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.ExporterBase/Properties/AssemblyInfo.cs
+++ b/src/Steeltoe.Management.ExporterBase/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.ExporterBase/Tracing/ITraceExporter.cs
+++ b/src/Steeltoe.Management.ExporterBase/Tracing/ITraceExporter.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.ExporterBase/Tracing/Zipkin/ITraceExporterOptions.cs
+++ b/src/Steeltoe.Management.ExporterBase/Tracing/Zipkin/ITraceExporterOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.ExporterBase/Tracing/Zipkin/TraceExporter.cs
+++ b/src/Steeltoe.Management.ExporterBase/Tracing/Zipkin/TraceExporter.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.ExporterBase/Tracing/Zipkin/TraceExporterHandler.cs
+++ b/src/Steeltoe.Management.ExporterBase/Tracing/Zipkin/TraceExporterHandler.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.ExporterBase/Tracing/Zipkin/TraceExporterOptions.cs
+++ b/src/Steeltoe.Management.ExporterBase/Tracing/Zipkin/TraceExporterOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.ExporterBase/Tracing/Zipkin/ZipkinAnnotation.cs
+++ b/src/Steeltoe.Management.ExporterBase/Tracing/Zipkin/ZipkinAnnotation.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.ExporterBase/Tracing/Zipkin/ZipkinEndpoint.cs
+++ b/src/Steeltoe.Management.ExporterBase/Tracing/Zipkin/ZipkinEndpoint.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.ExporterBase/Tracing/Zipkin/ZipkinSpan.cs
+++ b/src/Steeltoe.Management.ExporterBase/Tracing/Zipkin/ZipkinSpan.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.ExporterBase/Tracing/Zipkin/ZipkinSpanKind.cs
+++ b/src/Steeltoe.Management.ExporterBase/Tracing/Zipkin/ZipkinSpanKind.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.ExporterCore/Metrics/CloudFoundryForwarder/EndpointApplicationBuilderExtensions.cs
+++ b/src/Steeltoe.Management.ExporterCore/Metrics/CloudFoundryForwarder/EndpointApplicationBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.ExporterCore/Metrics/CloudFoundryForwarder/EndpointServiceCollectionExtensions.cs
+++ b/src/Steeltoe.Management.ExporterCore/Metrics/CloudFoundryForwarder/EndpointServiceCollectionExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.ExporterCore/Properties/AssemblyInfo.cs
+++ b/src/Steeltoe.Management.ExporterCore/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.ExporterCore/Tracing/Zipkin/ZipkinExporterApplicationBuilderExtensions.cs
+++ b/src/Steeltoe.Management.ExporterCore/Tracing/Zipkin/ZipkinExporterApplicationBuilderExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.ExporterCore/Tracing/Zipkin/ZipkinExporterServiceCollectionExtensions.cs
+++ b/src/Steeltoe.Management.ExporterCore/Tracing/Zipkin/ZipkinExporterServiceCollectionExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.OpenCensus/Properties/AssemblyInfo.cs
+++ b/src/Steeltoe.Management.OpenCensus/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.TracingBase/ITracingOptions.cs
+++ b/src/Steeltoe.Management.TracingBase/ITracingOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.TracingBase/Observer/HttpClientCoreObserver.cs
+++ b/src/Steeltoe.Management.TracingBase/Observer/HttpClientCoreObserver.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.TracingBase/Observer/HttpClientDesktopObserver.cs
+++ b/src/Steeltoe.Management.TracingBase/Observer/HttpClientDesktopObserver.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.TracingBase/Observer/HttpClientTracingObserver.cs
+++ b/src/Steeltoe.Management.TracingBase/Observer/HttpClientTracingObserver.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.TracingBase/OpenCensusTracing.cs
+++ b/src/Steeltoe.Management.TracingBase/OpenCensusTracing.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.TracingBase/Properties/AssemblyInfo.cs
+++ b/src/Steeltoe.Management.TracingBase/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.TracingBase/TracingLogProcessor.cs
+++ b/src/Steeltoe.Management.TracingBase/TracingLogProcessor.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.TracingBase/TracingOptions.cs
+++ b/src/Steeltoe.Management.TracingBase/TracingOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.TracingCore/Observer/AspNetCoreHostingObserver.cs
+++ b/src/Steeltoe.Management.TracingCore/Observer/AspNetCoreHostingObserver.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.TracingCore/Observer/AspNetCoreMvcActionObserver.cs
+++ b/src/Steeltoe.Management.TracingCore/Observer/AspNetCoreMvcActionObserver.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.TracingCore/Observer/AspNetCoreMvcViewObserver.cs
+++ b/src/Steeltoe.Management.TracingCore/Observer/AspNetCoreMvcViewObserver.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.TracingCore/Observer/AspNetCoreTracingObserver.cs
+++ b/src/Steeltoe.Management.TracingCore/Observer/AspNetCoreTracingObserver.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.TracingCore/Properties/AssemblyInfo.cs
+++ b/src/Steeltoe.Management.TracingCore/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.TracingCore/TracingService.cs
+++ b/src/Steeltoe.Management.TracingCore/TracingService.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Steeltoe.Management.TracingCore/TracingServiceCollectionExtensions.cs
+++ b/src/Steeltoe.Management.TracingCore/TracingServiceCollectionExtensions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.CloudFoundryCore.Test/CloudFoundryApplicationBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.CloudFoundryCore.Test/CloudFoundryApplicationBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.CloudFoundryCore.Test/CloudFoundryServiceCollectionExtensionsTest.cs
+++ b/test/Steeltoe.Management.CloudFoundryCore.Test/CloudFoundryServiceCollectionExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/AbstractEndpointTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/AbstractEndpointTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/AbstractOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/AbstractOptionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/BaseTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/BaseTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/CloudFoundry/CloudFoundryEndpointTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/CloudFoundry/CloudFoundryEndpointTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/CloudFoundry/CloudFoundryOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/CloudFoundry/CloudFoundryOptionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/CloudFoundry/SecurityBaseTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/CloudFoundry/SecurityBaseTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Discovery/ActuatorDiscoveryOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Discovery/ActuatorDiscoveryOptionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Discovery/DiscoveryEndpointTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Discovery/DiscoveryEndpointTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Env/EnvEndpointTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Env/EnvEndpointTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Env/EnvOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Env/EnvOptionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Env/EnvironmentDescriptorTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Env/EnvironmentDescriptorTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Env/PropertySourceDescriptorTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Env/PropertySourceDescriptorTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Env/PropertyValueDescriptorTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Env/PropertyValueDescriptorTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Health/Contributor/DiskSpaceContributorOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Health/Contributor/DiskSpaceContributorOptionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Health/Contributor/DiskSpaceContributorTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Health/Contributor/DiskSpaceContributorTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Health/DefaultHealthAggregatorTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Health/DefaultHealthAggregatorTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Health/HealthData.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Health/HealthData.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Health/HealthEndpointTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Health/HealthEndpointTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Health/HealthOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Health/HealthOptionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Health/HealthTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Health/HealthTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Health/MockContributors/DownContributor.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Health/MockContributors/DownContributor.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Health/MockContributors/OutOfSserviceContributor.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Health/MockContributors/OutOfSserviceContributor.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Health/MockContributors/TestContrib.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Health/MockContributors/TestContrib.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Health/MockContributors/UnknownContributor.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Health/MockContributors/UnknownContributor.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Health/MockContributors/UpContributor.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Health/MockContributors/UpContributor.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/HeapDump/HeapDumpEndpointTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/HeapDump/HeapDumpEndpointTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/HeapDump/HeapDumpOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/HeapDump/HeapDumpOptionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Info/AppSettingsInfoContributorTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Info/AppSettingsInfoContributorTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Info/Contributor/AppSettingsInfoContributorTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Info/Contributor/AppSettingsInfoContributorTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Info/Contributor/GitInfoContributorTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Info/Contributor/GitInfoContributorTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Info/GitInfoContributorTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Info/GitInfoContributorTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Info/InfoBuilderTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Info/InfoBuilderTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Info/InfoEndpointTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Info/InfoEndpointTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Info/InfoOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Info/InfoOptionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Info/TestContrib.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Info/TestContrib.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Loggers/LoggerLevelsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Loggers/LoggerLevelsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Loggers/LoggersChangeRequestTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Loggers/LoggersChangeRequestTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Loggers/LoggersEndpointTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Loggers/LoggersEndpointTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Loggers/LoggersOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Loggers/LoggersOptionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Loggers/TestLogProvider.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Loggers/TestLogProvider.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/ManagementOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/ManagementOptionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Mappings/ApplicationMappingsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Mappings/ApplicationMappingsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Mappings/ContextMappingsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Mappings/ContextMappingsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Mappings/MappingDescriptionTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Mappings/MappingDescriptionTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Mappings/MappingsOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Mappings/MappingsOptionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Mappings/TestRouteDetails.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Mappings/TestRouteDetails.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Metrics/MetricSampleTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Metrics/MetricSampleTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Metrics/MetricTagTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Metrics/MetricTagTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Metrics/MetricsEndpointTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Metrics/MetricsEndpointTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Metrics/MetricsListNamesResponseTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Metrics/MetricsListNamesResponseTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Metrics/MetricsOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Metrics/MetricsOptionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Metrics/MetricsRequestTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Metrics/MetricsRequestTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Metrics/MetricsResponseTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Metrics/MetricsResponseTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Metrics/Observer/CLRRuntimeObserverTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Metrics/Observer/CLRRuntimeObserverTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Metrics/Observer/CLRRuntimeSourceTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Metrics/Observer/CLRRuntimeSourceTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Metrics/Observer/HttpClientCoreObserverTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Metrics/Observer/HttpClientCoreObserverTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Metrics/Observer/HttpClientDesktopObserverTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Metrics/Observer/HttpClientDesktopObserverTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Middleware/EndpointMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Middleware/EndpointMiddlewareTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Refresh/RefreshEndpointTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Refresh/RefreshEndpointTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Refresh/RefreshOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Refresh/RefreshOptionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Steeltoe.Management.EndpointBase.Test.csproj
+++ b/test/Steeltoe.Management.EndpointBase.Test/Steeltoe.Management.EndpointBase.Test.csproj
@@ -10,7 +10,7 @@
     <PackageId>Steeltoe.Management.EndpointBase.Test</PackageId>
     <PackageTags>Spring Cloud;Actuator;Management;Monitoring</PackageTags>
     <PackageProjectUrl>http://steeltoe.io</PackageProjectUrl>
-    <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
+    <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
   </PropertyGroup>
 
   <Import Project="..\..\targetframework.props" />

--- a/test/Steeltoe.Management.EndpointBase.Test/TestEndpoint.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/TestEndpoint.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/TestHelpers.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/TestHelpers.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/TestOptions.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/TestOptions.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/TestOptions2.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/TestOptions2.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/ThreadDump/TestThreadDumper.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/ThreadDump/TestThreadDumper.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/ThreadDump/ThreadDumpEndpointTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/ThreadDump/ThreadDumpEndpointTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/ThreadDump/ThreadDumpOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/ThreadDump/ThreadDumpOptionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Trace/TestTraceEndpoint.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Trace/TestTraceEndpoint.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Trace/TestTraceRepo.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Trace/TestTraceRepo.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Trace/TraceEndpointTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Trace/TraceEndpointTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointBase.Test/Trace/TraceOptionsTest.cs
+++ b/test/Steeltoe.Management.EndpointBase.Test/Trace/TraceOptionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/CloudFoundry/CloudFoundrySecurityMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/CloudFoundry/CloudFoundrySecurityMiddlewareTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/CloudFoundry/EndpointApplicationBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/CloudFoundry/EndpointApplicationBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/CloudFoundry/EndpointMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/CloudFoundry/EndpointMiddlewareTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/CloudFoundry/EndpointServiceCollectionTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/CloudFoundry/EndpointServiceCollectionTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/CloudFoundry/Startup.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/CloudFoundry/Startup.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/CloudFoundry/StartupWithSecurity.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/CloudFoundry/StartupWithSecurity.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/CloudFoundry/TestCloudFoundryEndpoint.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/CloudFoundry/TestCloudFoundryEndpoint.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Discovery/EndpointApplicationBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Discovery/EndpointApplicationBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Discovery/EndpointMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Discovery/EndpointMiddlewareTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Discovery/EndpointServiceCollectionTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Discovery/EndpointServiceCollectionTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Discovery/Startup.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Discovery/Startup.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Discovery/StartupWithSecurity.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Discovery/StartupWithSecurity.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Discovery/TestDiscoveryEndpoint.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Discovery/TestDiscoveryEndpoint.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Env/EndpointApplicationBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Env/EndpointApplicationBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Env/EndpointMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Env/EndpointMiddlewareTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Env/EndpointServiceCollectionTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Env/EndpointServiceCollectionTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Env/Startup.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Env/Startup.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Health/AuthStartup.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Health/AuthStartup.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Health/EndpointApplicationBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Health/EndpointApplicationBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Health/EndpointMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Health/EndpointMiddlewareTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Health/EndpointServiceCollectionTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Health/EndpointServiceCollectionTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Health/Startup.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Health/Startup.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Health/TestContributor.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Health/TestContributor.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Health/TestHealthCheck.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Health/TestHealthCheck.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Health/TestHealthEndpoint.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Health/TestHealthEndpoint.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/HeapDump/EndpointApplicationBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/HeapDump/EndpointApplicationBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/HeapDump/EndpointMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/HeapDump/EndpointMiddlewareTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/HeapDump/EndpointServiceCollectionTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/HeapDump/EndpointServiceCollectionTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/HeapDump/Startup.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/HeapDump/Startup.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Info/EndpointApplicationBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Info/EndpointApplicationBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Info/EndpointMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Info/EndpointMiddlewareTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Info/EndpointServiceCollectionTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Info/EndpointServiceCollectionTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Info/Startup.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Info/Startup.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Info/TestInfoContributor.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Info/TestInfoContributor.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Info/TestInfoEndpoint.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Info/TestInfoEndpoint.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Info/TestLogger.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Info/TestLogger.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Loggers/EndpointApplicationBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Loggers/EndpointApplicationBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Loggers/EndpointMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Loggers/EndpointMiddlewareTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Loggers/EndpointServiceCollectionTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Loggers/EndpointServiceCollectionTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Loggers/Startup.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Loggers/Startup.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Loggers/TestLoggersEndpoint.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Loggers/TestLoggersEndpoint.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Mappings/EndpointApplicationBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Mappings/EndpointApplicationBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Mappings/EndpointMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Mappings/EndpointMiddlewareTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Mappings/EndpointServiceCollectionTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Mappings/EndpointServiceCollectionTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Mappings/HomeController.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Mappings/HomeController.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Mappings/Person.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Mappings/Person.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Mappings/Startup.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Mappings/Startup.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Metrics/EndpointServiceCollectionExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Metrics/EndpointServiceCollectionExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Metrics/MetricsEndpointMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Metrics/MetricsEndpointMiddlewareTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Metrics/Observer/AspNetCoreHostingObserverTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Metrics/Observer/AspNetCoreHostingObserverTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Refresh/EndpointApplicationBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Refresh/EndpointApplicationBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Refresh/EndpointMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Refresh/EndpointMiddlewareTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Refresh/EndpointServiceCollectionTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Refresh/EndpointServiceCollectionTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Refresh/Startup.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Refresh/Startup.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Security/SecureStartup.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Security/SecureStartup.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Security/SetsUserInContextForTestsMiddleware.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Security/SetsUserInContextForTestsMiddleware.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Security/Startup.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Security/Startup.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Steeltoe.Management.EndpointCore.Test.csproj
+++ b/test/Steeltoe.Management.EndpointCore.Test/Steeltoe.Management.EndpointCore.Test.csproj
@@ -9,7 +9,7 @@
     <PackageId>Steeltoe.Management.EndpointCore.Test</PackageId>
     <PackageTags>Spring Cloud;Actuator;Management;Monitoring</PackageTags>
     <PackageProjectUrl>http://steeltoe.io</PackageProjectUrl>
-    <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
+    <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
   </PropertyGroup>
 
   <Import Project="..\..\targetframework.props" />

--- a/test/Steeltoe.Management.EndpointCore.Test/TestHelpers.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/TestHelpers.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/ThreadDump/EndpointApplicationBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/ThreadDump/EndpointApplicationBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/ThreadDump/EndpointMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/ThreadDump/EndpointMiddlewareTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/ThreadDump/EndpointServiceCollectionTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/ThreadDump/EndpointServiceCollectionTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/ThreadDump/Startup.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/ThreadDump/Startup.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Trace/EndpointApplicationBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Trace/EndpointApplicationBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Trace/EndpointMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Trace/EndpointMiddlewareTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Trace/EndpointServiceCollectionTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Trace/EndpointServiceCollectionTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Trace/MyIdentity.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Trace/MyIdentity.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Trace/SessionFeature.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Trace/SessionFeature.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Trace/Startup.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Trace/Startup.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Trace/TestSession.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Trace/TestSession.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Trace/TestTraceEndpoint.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Trace/TestTraceEndpoint.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointCore.Test/Trace/TraceDiagnosticObserverTest.cs
+++ b/test/Steeltoe.Management.EndpointCore.Test/Trace/TraceDiagnosticObserverTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/CloudFoundry/CloudFoundryEndpointAppBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/CloudFoundry/CloudFoundryEndpointAppBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/CloudFoundry/CloudFoundryEndpointOwinMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/CloudFoundry/CloudFoundryEndpointOwinMiddlewareTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/CloudFoundry/CloudFoundrySecurityAppBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/CloudFoundry/CloudFoundrySecurityAppBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/CloudFoundry/CloudFoundrySecurityMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/CloudFoundry/CloudFoundrySecurityMiddlewareTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/CloudFoundry/Startup.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/CloudFoundry/Startup.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/CloudFoundry/StartupWithSecurity.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/CloudFoundry/StartupWithSecurity.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/CloudFoundry/TestCloudFoundryEndpoint.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/CloudFoundry/TestCloudFoundryEndpoint.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Discovery/ActuatorySecurityMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Discovery/ActuatorySecurityMiddlewareTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Discovery/DiscoveryEndpointAppBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Discovery/DiscoveryEndpointAppBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Discovery/DiscoveryEndpointOwinMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Discovery/DiscoveryEndpointOwinMiddlewareTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Discovery/DiscoverySecurityAppBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Discovery/DiscoverySecurityAppBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Discovery/Startup.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Discovery/Startup.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Discovery/StartupWithSecurity.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Discovery/StartupWithSecurity.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Discovery/TestActuatorDiscoveryEndpoint.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Discovery/TestActuatorDiscoveryEndpoint.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Env/EnvEndpointAppBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Env/EnvEndpointAppBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Env/EnvOwinMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Env/EnvOwinMiddlewareTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Env/Startup.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Env/Startup.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Health/HealthEndpointAppBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Health/HealthEndpointAppBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Health/HealthEndpointOwinMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Health/HealthEndpointOwinMiddlewareTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Health/Startup.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Health/Startup.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Health/TestHealthEndpoint.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Health/TestHealthEndpoint.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/HeapDump/HeapDumpEndpointAppBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/HeapDump/HeapDumpEndpointAppBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/HeapDump/HeapDumpEndpointOwinMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/HeapDump/HeapDumpEndpointOwinMiddlewareTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/HeapDump/Startup.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/HeapDump/Startup.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Info/InfoEndpointAppBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Info/InfoEndpointAppBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Info/InfoEndpointOwinMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Info/InfoEndpointOwinMiddlewareTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Info/Startup.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Info/Startup.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Info/TestInfoEndpoint.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Info/TestInfoEndpoint.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Loggers/LoggersEndpointAppBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Loggers/LoggersEndpointAppBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Loggers/LoggersEndpointOwinMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Loggers/LoggersEndpointOwinMiddlewareTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Loggers/Startup.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Loggers/Startup.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Loggers/TestLoggersEndpoint.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Loggers/TestLoggersEndpoint.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Metrics/MetricsEndpointAppBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Metrics/MetricsEndpointAppBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Metrics/MetricsEndpointOwinMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Metrics/MetricsEndpointOwinMiddlewareTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Metrics/Startup.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Metrics/Startup.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/OwinTestHelpers.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/OwinTestHelpers.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Refresh/RefreshEndpointAppBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Refresh/RefreshEndpointAppBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Refresh/RefreshEndpointOwinMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Refresh/RefreshEndpointOwinMiddlewareTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Refresh/Startup.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Refresh/Startup.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Security/AuthenticationTestMiddleware.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Security/AuthenticationTestMiddleware.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Security/SecureStartup.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Security/SecureStartup.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Security/Startup.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Security/Startup.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/ThreadDump/Startup.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/ThreadDump/Startup.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/ThreadDump/ThreadDumpEndpointAppBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/ThreadDump/ThreadDumpEndpointAppBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/ThreadDump/ThreadDumpEndpointOwinMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/ThreadDump/ThreadDumpEndpointOwinMiddlewareTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Trace/MyIdentity.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Trace/MyIdentity.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Trace/Startup.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Trace/Startup.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Trace/TestTraceEndpoint.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Trace/TestTraceEndpoint.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Trace/TraceEndpointAppBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Trace/TraceEndpointAppBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwin.Test/Trace/TraceEndpointOwinMiddlewareTest.cs
+++ b/test/Steeltoe.Management.EndpointOwin.Test/Trace/TraceEndpointOwinMiddlewareTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwinAutofac.Test/Actuators/CloudFoundryContainerBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointOwinAutofac.Test/Actuators/CloudFoundryContainerBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwinAutofac.Test/Actuators/EnvContainerBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointOwinAutofac.Test/Actuators/EnvContainerBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwinAutofac.Test/Actuators/HealthContainerBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointOwinAutofac.Test/Actuators/HealthContainerBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwinAutofac.Test/Actuators/HeapDumpContainerBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointOwinAutofac.Test/Actuators/HeapDumpContainerBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwinAutofac.Test/Actuators/InfoContainerBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointOwinAutofac.Test/Actuators/InfoContainerBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwinAutofac.Test/Actuators/LoggersContainerBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointOwinAutofac.Test/Actuators/LoggersContainerBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwinAutofac.Test/Actuators/MappingsContainerBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointOwinAutofac.Test/Actuators/MappingsContainerBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwinAutofac.Test/Actuators/MetricsContainerBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointOwinAutofac.Test/Actuators/MetricsContainerBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwinAutofac.Test/Actuators/RefreshContainerBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointOwinAutofac.Test/Actuators/RefreshContainerBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwinAutofac.Test/Actuators/ThreadDumpContainerBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointOwinAutofac.Test/Actuators/ThreadDumpContainerBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointOwinAutofac.Test/Actuators/TraceContainerBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Management.EndpointOwinAutofac.Test/Actuators/TraceContainerBuilderExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointWeb.Test/ActuatorHandlerTest.cs
+++ b/test/Steeltoe.Management.EndpointWeb.Test/ActuatorHandlerTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointWeb.Test/DefaultTestSettingsConfig.cs
+++ b/test/Steeltoe.Management.EndpointWeb.Test/DefaultTestSettingsConfig.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointWeb.Test/ManagementConfig.cs
+++ b/test/Steeltoe.Management.EndpointWeb.Test/ManagementConfig.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointWeb.Test/TestServer/Settings.cs
+++ b/test/Steeltoe.Management.EndpointWeb.Test/TestServer/Settings.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointWeb.Test/TestServer/TestHttpClient.cs
+++ b/test/Steeltoe.Management.EndpointWeb.Test/TestServer/TestHttpClient.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointWeb.Test/TestServer/TestRequest.cs
+++ b/test/Steeltoe.Management.EndpointWeb.Test/TestServer/TestRequest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointWeb.Test/TestServer/TestResponse.cs
+++ b/test/Steeltoe.Management.EndpointWeb.Test/TestServer/TestResponse.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointWeb.Test/TestServer/TestServer.cs
+++ b/test/Steeltoe.Management.EndpointWeb.Test/TestServer/TestServer.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.EndpointWeb.Test/TestServer/TestUser.cs
+++ b/test/Steeltoe.Management.EndpointWeb.Test/TestServer/TestUser.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.ExporterBase.Test/Metrics/CloudFoundryForwarder/ApplicationTest.cs
+++ b/test/Steeltoe.Management.ExporterBase.Test/Metrics/CloudFoundryForwarder/ApplicationTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.ExporterBase.Test/Metrics/CloudFoundryForwarder/BaseTest.cs
+++ b/test/Steeltoe.Management.ExporterBase.Test/Metrics/CloudFoundryForwarder/BaseTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.ExporterBase.Test/Metrics/CloudFoundryForwarder/CloudFoundryForwarderExporterTest.cs
+++ b/test/Steeltoe.Management.ExporterBase.Test/Metrics/CloudFoundryForwarder/CloudFoundryForwarderExporterTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.ExporterBase.Test/Metrics/CloudFoundryForwarder/CloudFoundryForwarderOptionsTest.cs
+++ b/test/Steeltoe.Management.ExporterBase.Test/Metrics/CloudFoundryForwarder/CloudFoundryForwarderOptionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.ExporterBase.Test/Metrics/CloudFoundryForwarder/InstanceTest.cs
+++ b/test/Steeltoe.Management.ExporterBase.Test/Metrics/CloudFoundryForwarder/InstanceTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.ExporterBase.Test/Metrics/CloudFoundryForwarder/MessageTest.cs
+++ b/test/Steeltoe.Management.ExporterBase.Test/Metrics/CloudFoundryForwarder/MessageTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.ExporterBase.Test/Metrics/CloudFoundryForwarder/MetricTest.cs
+++ b/test/Steeltoe.Management.ExporterBase.Test/Metrics/CloudFoundryForwarder/MetricTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.ExporterBase.Test/Metrics/CloudFoundryForwarder/MicrometerMetricWriterTest.cs
+++ b/test/Steeltoe.Management.ExporterBase.Test/Metrics/CloudFoundryForwarder/MicrometerMetricWriterTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.ExporterBase.Test/Metrics/CloudFoundryForwarder/OpenCensusStats.cs
+++ b/test/Steeltoe.Management.ExporterBase.Test/Metrics/CloudFoundryForwarder/OpenCensusStats.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.ExporterBase.Test/Metrics/CloudFoundryForwarder/SpringBootMetricWriterTest.cs
+++ b/test/Steeltoe.Management.ExporterBase.Test/Metrics/CloudFoundryForwarder/SpringBootMetricWriterTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.ExporterBase.Test/Steeltoe.Management.ExporterBase.Test.csproj
+++ b/test/Steeltoe.Management.ExporterBase.Test/Steeltoe.Management.ExporterBase.Test.csproj
@@ -10,7 +10,7 @@
     <PackageId>Steeltoe.Management.ExporterBase.Test</PackageId>
     <PackageTags>Spring Cloud;Actuator;Management;Monitoring;Tracing;Metrics</PackageTags>
     <PackageProjectUrl>http://steeltoe.io</PackageProjectUrl>
-    <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
+    <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
   </PropertyGroup>
 
   <Import Project="..\..\targetframework.props" />

--- a/test/Steeltoe.Management.ExporterBase.Test/Tracing/Zipkin/TraceExporterHandlerTest.cs
+++ b/test/Steeltoe.Management.ExporterBase.Test/Tracing/Zipkin/TraceExporterHandlerTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.ExporterBase.Test/Tracing/Zipkin/TraceExporterOptionsTest.cs
+++ b/test/Steeltoe.Management.ExporterBase.Test/Tracing/Zipkin/TraceExporterOptionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.ExporterCore.Test/Steeltoe.Management.ExporterCore.Test.csproj
+++ b/test/Steeltoe.Management.ExporterCore.Test/Steeltoe.Management.ExporterCore.Test.csproj
@@ -10,7 +10,7 @@
     <PackageId>Steeltoe.Management.ExporterCore.Test</PackageId>
     <PackageTags>Spring Cloud;Actuator;Management;Monitoring;Tracing;Metrics</PackageTags>
     <PackageProjectUrl>http://steeltoe.io</PackageProjectUrl>
-    <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
+    <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
   </PropertyGroup>
 
   <Import Project="..\..\targetframework.props" />

--- a/test/Steeltoe.Management.ExporterCore.Test/Tracing/Zipkin/ZipkinExporterServiceCollectionExtensionsTest.cs
+++ b/test/Steeltoe.Management.ExporterCore.Test/Tracing/Zipkin/ZipkinExporterServiceCollectionExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.OpenCensus.Test/Steeltoe.Management.OpenCensus.Test.csproj
+++ b/test/Steeltoe.Management.OpenCensus.Test/Steeltoe.Management.OpenCensus.Test.csproj
@@ -9,7 +9,7 @@
     <PackageId>Steeltoe.Management.OpenCensus.Test</PackageId>
     <PackageTags>OpenCensus;Tracing;Management;Monitoring</PackageTags>
     <PackageProjectUrl>http://steeltoe.io</PackageProjectUrl>
-    <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
+    <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     <RootNamespace>Steeltoe.Management.Census</RootNamespace>
   </PropertyGroup>
 

--- a/test/Steeltoe.Management.TracingBase.Test/Observer/HttpClientCoreObserverTest.cs
+++ b/test/Steeltoe.Management.TracingBase.Test/Observer/HttpClientCoreObserverTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.TracingBase.Test/Observer/HttpClientDesktopObserverTest.cs
+++ b/test/Steeltoe.Management.TracingBase.Test/Observer/HttpClientDesktopObserverTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.TracingBase.Test/OpernCensusTracingTest.cs
+++ b/test/Steeltoe.Management.TracingBase.Test/OpernCensusTracingTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.TracingBase.Test/Steeltoe.Management.TracingBase.Test.csproj
+++ b/test/Steeltoe.Management.TracingBase.Test/Steeltoe.Management.TracingBase.Test.csproj
@@ -10,7 +10,7 @@
     <PackageId>Steeltoe.Management.TracingBase.Test</PackageId>
     <PackageTags>Spring Cloud;Actuator;Management;Monitoring;Tracing</PackageTags>
     <PackageProjectUrl>http://steeltoe.io</PackageProjectUrl>
-    <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
+    <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
   </PropertyGroup>
 
   <Import Project="..\..\targetframework.props" />

--- a/test/Steeltoe.Management.TracingBase.Test/TracingLogProcessorTest.cs
+++ b/test/Steeltoe.Management.TracingBase.Test/TracingLogProcessorTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.TracingBase.Test/TracingOptionsTest.cs
+++ b/test/Steeltoe.Management.TracingBase.Test/TracingOptionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.TracingCore.Test/Observer/AspNetCoreHostingObserverTest.cs
+++ b/test/Steeltoe.Management.TracingCore.Test/Observer/AspNetCoreHostingObserverTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.TracingCore.Test/Observer/AspNetCoreMvcActionObserverTest.cs
+++ b/test/Steeltoe.Management.TracingCore.Test/Observer/AspNetCoreMvcActionObserverTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.TracingCore.Test/Observer/AspNetCoreMvcViewObserverTest.cs
+++ b/test/Steeltoe.Management.TracingCore.Test/Observer/AspNetCoreMvcViewObserverTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.TracingCore.Test/Steeltoe.Management.TracingCore.Test.csproj
+++ b/test/Steeltoe.Management.TracingCore.Test/Steeltoe.Management.TracingCore.Test.csproj
@@ -10,7 +10,7 @@
     <PackageId>Steeltoe.Management.TracingCore.Test</PackageId>
     <PackageTags>Spring Cloud;Actuator;Management;Monitoring;Tracing</PackageTags>
     <PackageProjectUrl>http://steeltoe.io</PackageProjectUrl>
-    <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
+    <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
   </PropertyGroup>
 
   <Import Project="..\..\targetframework.props" />

--- a/test/Steeltoe.Management.TracingCore.Test/TestBase.cs
+++ b/test/Steeltoe.Management.TracingCore.Test/TestBase.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Steeltoe.Management.TracingCore.Test/TracingServiceCollectionExtensionsTest.cs
+++ b/test/Steeltoe.Management.TracingCore.Test/TracingServiceCollectionExtensionsTest.cs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 3 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 581 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).